### PR TITLE
Example submission conformance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.hdf5
 *.mat
+*.png
 .venv/
 __pycache__/
 .env

--- a/examples/nv-raw2insights-us/LICENSE
+++ b/examples/nv-raw2insights-us/LICENSE
@@ -1,0 +1,396 @@
+Attribution 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.
+

--- a/examples/nv-raw2insights-us/README.md
+++ b/examples/nv-raw2insights-us/README.md
@@ -49,7 +49,7 @@ Environment setup is in the [main README](../../README.md). After `uv sync` and
 # 1. stream one sample from HF, write the zea-format HDF5
 uv run python examples/nv-raw2insights-us/convert.py
 
-# 2. load pipeline.yaml, beamform the raw channel data, write the 7-panel PNG
+# 2. beamform the raw channel data (writes pipeline.yaml + the 7-panel PNG)
 uv run python examples/nv-raw2insights-us/reconstruct.py
 ```
 
@@ -128,9 +128,10 @@ Not applicable — fully synthetic phantom data; no human or animal subjects, no
 
 ## Data Validation
 
-[`reconstruct.py`](reconstruct.py) loads [`pipeline.yaml`](pipeline.yaml) — a
-`zea.Pipeline` of DAS beamforming → envelope detection → normalization →
-log-compression — and reconstructs a B-mode directly from `raw_data`. Comparing
+[`reconstruct.py`](reconstruct.py) defines a `zea.Pipeline` of DAS beamforming →
+envelope detection → normalization → log-compression, saves it to
+[`pipeline.yaml`](pipeline.yaml), and reconstructs a B-mode directly from
+`raw_data`. Comparing
 it against the stored B-mode is a sanity check that the acquisition parameters
 and probe geometry are recorded correctly, and serves as a reproducible reference
 reconstruction. The script also renders the speed-of-sound map, a SoS-corrected

--- a/examples/nv-raw2insights-us/README.md
+++ b/examples/nv-raw2insights-us/README.md
@@ -1,3 +1,24 @@
+---
+pretty_name: NV-Raw2Insights-US Simulations
+license: cc-by-4.0
+task_categories:
+  - image-segmentation
+  - other
+tags:
+  - ultrasound
+  - rf
+  - openh-rf
+  - medical-imaging
+  - simulation
+  - beamforming
+  - sound-speed-estimation
+  - phase-aberration
+language:
+  - en
+size_categories:
+  - n<1K
+---
+
 # NV-Raw2Insights-US → OpenH-RF
 
 A worked **submission example**: convert one sample of the public

--- a/examples/nv-raw2insights-us/README.md
+++ b/examples/nv-raw2insights-us/README.md
@@ -1,14 +1,147 @@
-# NV-Raw2Insights-US → openh-rf
+# NV-Raw2Insights-US → OpenH-RF
 
-Convert one sample from [nvidia/NV-Raw2Insights-US](https://huggingface.co/datasets/nvidia/NV-Raw2Insights-US)
-to openh-rf HDF5, then beamform and visualize.
+A worked **submission example**: convert one sample of the public
+[`nvidia/NV-Raw2Insights-US`](https://huggingface.co/datasets/nvidia/NV-Raw2Insights-US)
+dataset into the OpenH-RF (`zea`) file format, then reconstruct a B-mode from the
+raw channel data to validate it.
 
-Environment setup is in the [main README](../../README.md). After `uv sync`:
+This directory follows the OpenH-RF Sub-Dataset Submission Guide. The **required
+submission files** are:
+
+| File | Role |
+|------|------|
+| `*.hdf5` | Acquisition(s) in [`zea` file format](https://zea.readthedocs.io/en/latest/data-acquisition.html) (one file per acquisition) |
+| [`reconstruct.py`](reconstruct.py) | Reference reconstruction → `.png`, driven by a `zea.Pipeline` |
+| [`pipeline.yaml`](pipeline.yaml) | The saved reconstruction pipeline |
+| `README.md` | This data card |
+| [`LICENSE`](LICENSE) | CC BY 4.0 |
+
+[`convert.py`](convert.py) is an **illustrative helper**, not part of the required
+set — it shows how the published HF dataset maps onto the `zea` format.
+
+## Running this example
+
+Environment setup is in the [main README](../../README.md). After `uv sync` and
+`export KERAS_BACKEND=jax`:
 
 ```bash
-# 1. stream one sample from HF, write HDF5
-uv run python examples/nv-raw2insights-us/convert_nv_raw2insights_us.py
+# 1. stream one sample from HF, write the zea-format HDF5
+uv run python examples/nv-raw2insights-us/convert.py
 
-# 2. beamform via zea, write 7-panel PNG
-uv run python examples/nv-raw2insights-us/reconstruct_nv_raw2insights_us.py
+# 2. load pipeline.yaml, beamform the raw channel data, write the 7-panel PNG
+uv run python examples/nv-raw2insights-us/reconstruct.py
+```
+
+---
+
+# Data Card — NV-Raw2Insights-US Simulations
+
+## Dataset Description
+
+NV-Raw2Insights-US Simulations is a simulated full synthetic aperture (FSA)
+ultrasound dataset for training and evaluating neural networks on sound speed
+estimation, phase aberration correction, and tissue segmentation. Each sample is
+a single-frame FSA acquisition from a 180-element linear array simulated (k-Wave)
+over a heterogeneous tissue phantom containing cysts. It provides raw baseband IQ
+channel data alongside ground-truth sound speed maps, binary cyst segmentation
+masks, and phase aberration values. **Data type: simulated.**
+
+Source dataset: <https://huggingface.co/datasets/nvidia/NV-Raw2Insights-US>
+
+## Dataset Contributor(s)
+
+NVIDIA Corporation. Contact: [wsimson@nvidia.com](mailto:wsimson@nvidia.com).
+
+## Dataset Creation Date
+
+12/01/2025
+
+## License / Terms of Use
+
+[Creative Commons Attribution 4.0 International (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/legalcode.en).
+The data is cleared for this license (synthetic data, no patient information).
+
+## Intended Usage
+
+Developing and benchmarking methods for ultrasound image reconstruction
+(learned beamforming), sound speed estimation, phase aberration correction, and
+tissue segmentation from raw channel data.
+
+## Dataset Characterization
+
+- **Data Collection Method:** synthetic (k-Wave acoustic simulation)
+- **Labeling Method:** synthetic ground truth (from simulation parameters)
+- **Acquisition system:** simulated 180-element linear array (10L4-style),
+  full synthetic aperture; sampling ~13.3 MHz, center frequency ~6.5 MHz,
+  background sound speed 1540 m/s.
+
+## Dataset Format
+
+Submitted in the [`zea` file format](https://zea.readthedocs.io/en/latest/data-acquisition.html)
+(one HDF5 file per acquisition). `convert.py` maps the source HF Arrow features
+onto `zea` groups: raw IQ channel data, stored B-modes, the sound-speed map, the
+segmentation, scan parameters, and the per-sample phase-error metric. B-modes are
+log-compressed to 8-bit before storage.
+
+Per-sample contents of the converted HDF5:
+
+| Group / field | Shape | Dtype | Units | Description |
+|---|---|---|---|---|
+| `data/raw_data` | `[1, n_tx, n_ax, n_el, 2]` | float32 | -- | Raw baseband IQ channel data; last axis is `[I, Q]` |
+| `data/image` | `[1, z, x]` | uint8 | dB | Stored DAS B-mode (log-compressed) + `extent` |
+| `data/bmode_focused` | `[1, z, x]` | uint8 | dB | Stored DBUA aberration-corrected B-mode + `extent` |
+| `data/sos_map` | `[1, 32, 32]` | float32 | m/s | Ground-truth speed-of-sound map + `extent` |
+| `data/segmentation` | `[1, z, x, 1, 2]` | bool | -- | Cyst masks; `labels = [background, inclusion]` + `extent` |
+| `scan/*` | -- | -- | -- | Probe geometry, sampling/center/demod frequency, t0, sound speed, … |
+| `metrics/common_midpoint_phase_error` | `[1]` | float32 | radians | Per-sample phase aberration error |
+
+## Dataset Quantification
+
+- 923 samples (830 train / 93 validation) in the source dataset.
+- ~265 MB per sample; ~245 GB total for the full source dataset.
+- This example converts a single streamed sample (~250 MB HDF5).
+
+## Subject Metadata
+
+Not applicable — fully synthetic phantom data; no human or animal subjects, no PHI.
+
+## Data Validation
+
+[`reconstruct.py`](reconstruct.py) loads [`pipeline.yaml`](pipeline.yaml) — a
+`zea.Pipeline` of DAS beamforming → envelope detection → normalization →
+log-compression — and reconstructs a B-mode directly from `raw_data`. Comparing
+it against the stored B-mode is a sanity check that the acquisition parameters
+and probe geometry are recorded correctly, and serves as a reproducible reference
+reconstruction. The script also renders the speed-of-sound map, a SoS-corrected
+reconstruction, and the segmentation overlay (7-panel figure).
+
+## Known Issues
+
+- The source HF dataset uses mixed units: `bmode_extent` is in millimetres while
+  `sound_speed_extent` and `elpos` are in metres. `convert.py` normalizes these
+  to metres on write.
+- The source `bmode_extent` z-axis ordering is `[x_min, x_max, z_max, z_min]`
+  (z_max before z_min); `convert.py` reorders it to the `zea` convention.
+
+## Ethical Considerations
+
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established
+policies and practices to enable development for a wide array of AI applications.
+This is fully synthetic data with no patient information. When downloaded or used
+in accordance with our terms of service, developers should ensure this dataset
+meets requirements for the relevant industry and use case. Please report quality,
+risk, or security concerns
+[here](https://www.nvidia.com/en-us/support/submit-security-vulnerability/).
+
+## Citation
+
+```bibtex
+@misc{nv_raw2insights_us_simulations_2026,
+  title={NV-Raw2Insights-US Simulations},
+  author={Simson, Walter and Huver, Sean},
+  year={2026},
+  publisher={NVIDIA Corporation},
+  howpublished={\url{https://huggingface.co/datasets/nvidia/NV-Raw2Insights-US}},
+  license={CC BY 4.0}
+}
 ```

--- a/examples/nv-raw2insights-us/convert.py
+++ b/examples/nv-raw2insights-us/convert.py
@@ -4,11 +4,14 @@ to openh-rf HDF5 via File.create.
 
 Source: https://huggingface.co/datasets/nvidia/NV-Raw2Insights-US
 
-Reproducible without a local copy: `datasets` streams a single example from
-the remote parquet shards.
+This is an *example* helper: it shows how the published HF dataset maps onto the
+openh-rf (zea) file format. A submission's required files are the .hdf5 data,
+reconstruct.py, pipeline.yaml, README.md and LICENSE; this converter is not part
+of that set. It is reproducible without a local copy -- `datasets` streams a
+single example from the remote parquet shards.
 
 Usage:
-    python examples/nv-raw2insights-us/convert_nv_raw2insights_us.py
+    python examples/nv-raw2insights-us/convert.py
 
 Note:
     Requires `datasets` library (`pip install datasets`)

--- a/examples/nv-raw2insights-us/convert.py
+++ b/examples/nv-raw2insights-us/convert.py
@@ -19,7 +19,12 @@ Note:
 """
 
 import argparse
+import os
 from pathlib import Path
+
+# Default to the jax backend (installed by `uv sync`) so the script runs under a
+# bare `uv run` without first exporting KERAS_BACKEND. An explicit value wins.
+os.environ.setdefault("KERAS_BACKEND", "jax")
 
 import numpy as np
 from datasets import load_dataset

--- a/examples/nv-raw2insights-us/pipeline.yaml
+++ b/examples/nv-raw2insights-us/pipeline.yaml
@@ -1,0 +1,12 @@
+pipeline:
+    operations:
+    -   name: beamform
+        params:
+            num_patches: 200
+    - envelope_detect
+    -   name: normalize
+        params:
+            output_range:
+            - 0.0
+            - 1.0
+    - log_compress

--- a/examples/nv-raw2insights-us/reconstruct.py
+++ b/examples/nv-raw2insights-us/reconstruct.py
@@ -16,7 +16,12 @@ Usage:
 """
 
 import argparse
+import os
 from pathlib import Path
+
+# Default to the jax backend (installed by `uv sync`) so the script runs under a
+# bare `uv run` without first exporting KERAS_BACKEND. An explicit value wins.
+os.environ.setdefault("KERAS_BACKEND", "jax")
 
 import keras
 import matplotlib

--- a/examples/nv-raw2insights-us/reconstruct.py
+++ b/examples/nv-raw2insights-us/reconstruct.py
@@ -1,13 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Beamform an openh-rf HDF5 sample produced by convert_nv_raw2insights_us.py.
+"""Beamform an openh-rf HDF5 sample produced by convert.py.
 
-Loads raw IQ + scan from the file via zea.File, runs DAS -> envelope ->
-normalize -> log-compress, and renders a 7-panel figure in the same style as
-sample_visualization.png (IQ energy, stored DAS B-mode, DBUA B-mode,
+Loads raw IQ + scan from the file via zea.File, applies the reconstruction
+pipeline defined in pipeline.yaml (DAS -> envelope -> normalize -> log-compress),
+and renders a 7-panel figure (IQ energy, stored DAS B-mode, DBUA B-mode,
 zea-reconstructed B-mode, zea SoS-corrected B-mode, speed of sound, segmentation).
 
+This is the reference reconstruction / data-validation script for the
+submission: it reproduces a representative B-mode from the raw channel data,
+confirming the acquisition parameters and geometry are recorded correctly.
+
 Usage:
-    python examples/nv-raw2insights-us/reconstruct_nv_raw2insights_us.py \
+    python examples/nv-raw2insights-us/reconstruct.py \
         --input nv_raw2insights_us_sample.hdf5
 """
 
@@ -21,10 +25,11 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 import zea
-from zea.ops import Beamform, EnvelopeDetect, LogCompress, Normalize
 
+HERE = Path(__file__).parent
 DEFAULT_INPUT = Path("nv_raw2insights_us_sample.hdf5")
 DEFAULT_OUTPUT = Path("nv_raw2insights_us_reconstructed.png")
+DEFAULT_PIPELINE = HERE / "pipeline.yaml"
 
 
 def ext_to_imshow_mm(ext):
@@ -36,11 +41,12 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--input", type=Path, default=DEFAULT_INPUT)
     parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--pipeline", type=Path, default=DEFAULT_PIPELINE)
     args = parser.parse_args()
 
     if not args.input.exists():
         raise FileNotFoundError(
-            f"{args.input} not found. Run convert_nv_raw2insights_us.py first."
+            f"{args.input} not found. Run convert.py first."
         )
 
     zea.init_device()
@@ -62,17 +68,9 @@ def main():
 
     print(f"raw_data: {raw.shape}")
 
-    pipeline = zea.Pipeline(
-        operations=[
-            Beamform(
-                beamformer="delay_and_sum",
-                num_patches=200,  # increase with out-of-memory error
-            ),
-            EnvelopeDetect(),
-            Normalize(),
-            LogCompress(),
-        ]
-    )
+    # Reconstruction pipeline (DAS -> envelope -> normalize -> log-compress)
+    # is defined in pipeline.yaml so it can be shared and reproduced without code.
+    pipeline = zea.Pipeline.from_path(str(args.pipeline))
     params = pipeline.prepare_parameters(probe, scan)
     outputs = pipeline(**{pipeline.key: raw}, **params)
     recon = keras.ops.convert_to_numpy(outputs[pipeline.output_key])[0]

--- a/examples/nv-raw2insights-us/reconstruct.py
+++ b/examples/nv-raw2insights-us/reconstruct.py
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 """Beamform an openh-rf HDF5 sample produced by convert.py.
 
-Loads raw IQ + scan from the file via zea.File, applies the reconstruction
-pipeline defined in pipeline.yaml (DAS -> envelope -> normalize -> log-compress),
-and renders a 7-panel figure (IQ energy, stored DAS B-mode, DBUA B-mode,
-zea-reconstructed B-mode, zea SoS-corrected B-mode, speed of sound, segmentation).
+Loads raw IQ + scan from the file via zea.File, builds the reconstruction
+pipeline inline (DAS -> envelope -> normalize -> log-compress), saves it to
+pipeline.yaml for reuse, and renders a 7-panel figure (IQ energy, stored DAS
+B-mode, DBUA B-mode, zea-reconstructed B-mode, zea SoS-corrected B-mode, speed
+of sound, segmentation).
 
 This is the reference reconstruction / data-validation script for the
 submission: it reproduces a representative B-mode from the raw channel data,
@@ -30,6 +31,7 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 import zea
+from zea.ops import Beamform, EnvelopeDetect, LogCompress, Normalize
 
 HERE = Path(__file__).parent
 DEFAULT_INPUT = Path("nv_raw2insights_us_sample.hdf5")
@@ -46,7 +48,12 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--input", type=Path, default=DEFAULT_INPUT)
     parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
-    parser.add_argument("--pipeline", type=Path, default=DEFAULT_PIPELINE)
+    parser.add_argument(
+        "--pipeline",
+        type=Path,
+        default=DEFAULT_PIPELINE,
+        help="Path to write the saved pipeline YAML",
+    )
     args = parser.parse_args()
 
     if not args.input.exists():
@@ -73,9 +80,21 @@ def main():
 
     print(f"raw_data: {raw.shape}")
 
-    # Reconstruction pipeline (DAS -> envelope -> normalize -> log-compress)
-    # is defined in pipeline.yaml so it can be shared and reproduced without code.
-    pipeline = zea.Pipeline.from_path(str(args.pipeline))
+    # DAS -> envelope -> normalize -> log-compress. Saved to pipeline.yaml so the
+    # same chain can be reused without code (zea.Pipeline.from_path).
+    pipeline = zea.Pipeline(
+        operations=[
+            Beamform(
+                beamformer="delay_and_sum",
+                num_patches=200,  # raise if you hit out-of-memory during beamforming
+            ),
+            EnvelopeDetect(),
+            Normalize(),
+            LogCompress(),
+        ]
+    )
+    pipeline.to_yaml(str(args.pipeline))
+    print(f"Saved pipeline to {args.pipeline}")
     params = pipeline.prepare_parameters(probe, scan)
     outputs = pipeline(**{pipeline.key: raw}, **params)
     recon = keras.ops.convert_to_numpy(outputs[pipeline.output_key])[0]

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -22,7 +22,7 @@ LIGHT_SCRIPTS = [
 ]
 HEAVY_SCRIPTS = [
     ROOT / "examples" / "saving" / "verasonics_example.py",
-    ROOT / "examples" / "nv-raw2insights-us" / "convert_nv_raw2insights_us.py",
+    ROOT / "examples" / "nv-raw2insights-us" / "convert.py",
 ]
 
 


### PR DESCRIPTION
 ## What & why

  Restructures `examples/nv-raw2insights-us/` to match the OpenH-RF Sub-Dataset
  Submission Guide's required layout (`reconstruct.py` + `pipeline.yaml` +
  `README.md` data card + `LICENSE`), and fixes usability issues found while
  verifying it end-to-end.

  ## Changes

  - **`reconstruct.py`** (renamed from `reconstruct_nv_raw2insights_us.py`) —
    builds the `zea.Pipeline` inline (DAS → envelope → normalize → log-compress)
    and saves it to `pipeline.yaml` via `to_yaml`. The code is the canonical
    definition; the YAML is a generated, in-sync artifact.
  - **`pipeline.yaml`** (new) — the saved, reproducible reconstruction pipeline.
  - **`convert.py`** (renamed from `convert_nv_raw2insights_us.py`) — documented
    as an *illustrative helper*, not part of the required submission set.
  - **`README.md`** — rewritten as the guide's §3 data card (sourced from the
    NVIDIA NV-Raw2Insights-US dataset card), with HF YAML frontmatter
    (`license: cc-by-4.0`, `pretty_name`, `task_categories`, `tags`), the
    required-file table, and a link to the HF source dataset.
  - **`LICENSE`** (new) — CC BY 4.0 (data license).
  - **`KERAS_BACKEND` default** — both scripts `os.environ.setdefault(
    "KERAS_BACKEND", "jax")` before importing keras/zea, so a bare `uv run` works
    without exporting first (an explicit export still wins).
  - **`.gitignore`** — ignore generated `*.png` reconstruction artifacts.
  - **`tests/test_scripts.py`** — updated for the renamed `convert.py`.

  ## Verification

  Verified end-to-end against the pinned `zea==0.1.0a0`: `convert.py` streams one
  HF sample → 248 MB zea HDF5; `reconstruct.py` builds the pipeline, beamforms the
  raw channel data, and renders the 7-panel validation figure (both exit 0;
  phantom cysts resolved). The `pipeline.yaml` emitted by `reconstruct.py` is
  byte-identical to the committed one.