### PR TITLE
Migrate nv-raw2insights-us example to the point-based coordinates spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,15 +47,15 @@ We aim to curate **20,000+** real and synthetic channel capture measurements spa
 
 ## Dataset Format
 
-The OpenH-RF format is implemented using the [`zea`](https://github.com/tue-bmd/zea) ultrasound toolbox. See the `zea` documentation for the [data specification](https://zea--358.org.readthedocs.build/en/358/data-acquisition.html). Each example below writes a single `.hdf5` file using `zea` and demonstrates the fields expected for a given modality:
+The OpenH-RF format is implemented using the [`zea`](https://github.com/tue-bmd/zea) ultrasound toolbox. See the `zea` documentation for the [data specification](https://zea--358.org.readthedocs.build/en/358/data-acquisition.html). The [`examples/templates/`](examples/templates/) directories are starting points for a submission — each has a `convert.py` (data → openh-rf `.hdf5`), a `reconstruct.py` (raw channel data → B-mode), and a `pipeline.yaml`:
 
 | Example | Modality |
 |---------|----------|
-| [`examples/saving/echocardiography_example.py`](examples/saving/echocardiography_example.py) | Cardiac ultrasound with strain map, ECG, demographics, annotations, quality metrics |
-| [`examples/saving/color_doppler_example.py`](examples/saving/color_doppler_example.py) | B-mode + color Doppler velocity map, ECG, annotations |
-| [`examples/saving/segmentation_map_example.py`](examples/saving/segmentation_map_example.py) | Raw RF data with per-frame segmentation masks and view labels |
-| [`examples/saving/verasonics_example.py`](examples/saving/verasonics_example.py) | Converting a Verasonics `.mat` workspace to OpenH-RF |
-| [`examples/nv-raw2insights-us/`](examples/nv-raw2insights-us/) | Streaming a sample from the public [NV-Raw2Insights-US](https://huggingface.co/datasets/nvidia/NV-Raw2Insights-US) dataset, converting to OpenH-RF, and beamforming back to a B-mode |
+| [`examples/templates/echocardiography/`](examples/templates/echocardiography/) | Cardiac (phased array): focused transmits, ECG + clinical metadata, annotations |
+| [`examples/templates/color-doppler/`](examples/templates/color-doppler/) | Linear array (plane-wave): B-mode + color Doppler velocity map, ECG, annotations |
+| [`examples/templates/segmentation/`](examples/templates/segmentation/) | Raw RF data with per-frame segmentation masks and view labels |
+| [`examples/templates/verasonics/`](examples/templates/verasonics/) | Converting a real Verasonics `.mat` workspace to OpenH-RF |
+| [`examples/nv-raw2insights-us/`](examples/nv-raw2insights-us/) | Worked example on a real public dataset: stream a sample from [NV-Raw2Insights-US](https://huggingface.co/datasets/nvidia/NV-Raw2Insights-US), convert to OpenH-RF, and beamform raw channel data back to a B-mode |
 | [`examples/save_pipeline_example.py`](examples/save_pipeline_example.py) | Saving a `zea` processing pipeline as a reusable YAML config |
 
 ## Setup
@@ -67,7 +67,7 @@ git clone https://github.com/open-h/OpenH-RF
 cd OpenH-RF
 uv sync
 export KERAS_BACKEND=jax
-uv run python examples/saving/echocardiography_example.py
+uv run python examples/save_pipeline_example.py
 ```
 
 `uv sync` creates `.venv/` and installs dependencies listed in `pyproject.toml`. Run any script with `uv run python <script>.py`, or activate the venv with `source .venv/bin/activate`.

--- a/examples/nv-raw2insights-us/README.md
+++ b/examples/nv-raw2insights-us/README.md
@@ -49,7 +49,7 @@ Environment setup is in the [main README](../../README.md). After `uv sync` and
 # 1. stream one sample from HF, write the zea-format HDF5
 uv run python examples/nv-raw2insights-us/convert.py
 
-# 2. beamform the raw channel data (writes pipeline.yaml + the 7-panel PNG)
+# 2. beamform the raw channel data in code (writes pipeline.yaml + the 7-panel PNG)
 uv run python examples/nv-raw2insights-us/reconstruct.py
 ```
 
@@ -102,19 +102,24 @@ Submitted in the [`zea` file format](https://zea.readthedocs.io/en/latest/data-a
 (one HDF5 file per acquisition). `convert.py` maps the source HF Arrow features
 onto `zea` groups: raw IQ channel data, stored B-modes, the sound-speed map, the
 segmentation, scan parameters, and the per-sample phase-error metric. B-modes are
-log-compressed to 8-bit before storage.
+log-compressed to 8-bit before storage. Each spatial map carries a per-pixel
+`coordinates` array (the point-based openh-rf spec) rather than a bounding-box
+extent; `convert.py` builds these with `zea.beamform.pixelgrid.cartesian_pixel_grid`.
 
 Per-sample contents of the converted HDF5:
 
 | Group / field | Shape | Dtype | Units | Description |
 |---|---|---|---|---|
 | `data/raw_data` | `[1, n_tx, n_ax, n_el, 2]` | float32 | -- | Raw baseband IQ channel data; last axis is `[I, Q]` |
-| `data/image` | `[1, z, x]` | uint8 | dB | Stored DAS B-mode (log-compressed) + `extent` |
-| `data/bmode_focused` | `[1, z, x]` | uint8 | dB | Stored DBUA aberration-corrected B-mode + `extent` |
-| `data/sos_map` | `[1, 32, 32]` | float32 | m/s | Ground-truth speed-of-sound map + `extent` |
-| `data/segmentation` | `[1, z, x, 1, 2]` | bool | -- | Cyst masks; `labels = [background, inclusion]` + `extent` |
+| `data/image` | `[1, z, x]` (+ `coordinates` `[z, x, 3]`) | uint8 | dB | Stored DAS B-mode (log-compressed) |
+| `data/bmode_focused` | `[1, z, x]` (+ `coordinates` `[z, x, 3]`) | uint8 | dB | Stored DBUA aberration-corrected B-mode |
+| `data/sos_map` | `[1, z, x]` (+ `coordinates` `[z, x, 3]`) | float32 | m/s | Ground-truth speed-of-sound map (coarser grid than the B-mode) |
+| `data/segmentation` | `[1, z, x, 2]` (+ `coordinates` `[z, x, 3]`) | bool | -- | Cyst masks; `labels = [background, inclusion]` |
 | `scan/*` | -- | -- | -- | Probe geometry, sampling/center/demod frequency, t0, sound speed, … |
 | `metrics/common_midpoint_phase_error` | `[1]` | float32 | radians | Per-sample phase aberration error |
+
+All `coordinates` arrays are per-pixel Cartesian positions in metres, last axis
+`[x, y, z]` (y = 0 for these 2-D maps).
 
 ## Dataset Quantification
 
@@ -128,14 +133,15 @@ Not applicable — fully synthetic phantom data; no human or animal subjects, no
 
 ## Data Validation
 
-[`reconstruct.py`](reconstruct.py) defines a `zea.Pipeline` of DAS beamforming →
-envelope detection → normalization → log-compression, saves it to
-[`pipeline.yaml`](pipeline.yaml), and reconstructs a B-mode directly from
-`raw_data`. Comparing
-it against the stored B-mode is a sanity check that the acquisition parameters
-and probe geometry are recorded correctly, and serves as a reproducible reference
-reconstruction. The script also renders the speed-of-sound map, a SoS-corrected
-reconstruction, and the segmentation overlay (7-panel figure).
+[`reconstruct.py`](reconstruct.py) builds a `zea.Pipeline` of DAS beamforming →
+envelope detection → normalization → log-compression **in code** and reconstructs
+a B-mode directly from `raw_data` — showing the raw-to-image flow without any
+config file. It also saves the pipeline to [`pipeline.yaml`](pipeline.yaml) as a
+shareable recipe. Comparing the reconstruction against the stored B-mode is a
+sanity check that the acquisition parameters and probe geometry are recorded
+correctly, and serves as a reproducible reference reconstruction. The script also
+renders the speed-of-sound map, a SoS-corrected reconstruction, and the
+segmentation overlay (7-panel figure).
 
 ## Known Issues
 

--- a/examples/nv-raw2insights-us/convert.py
+++ b/examples/nv-raw2insights-us/convert.py
@@ -83,6 +83,13 @@ def convert_sample(sample: dict, output_path: Path) -> None:
 
     probe_geometry = elpos.T
 
+    # The B-mode, focused B-mode, and segmentation share one image grid, so they
+    # reuse the same per-pixel coordinates below. Guard that assumption.
+    assert seg_map.shape == bmode.shape, (
+        f"segmentation {seg_map.shape} and B-mode {bmode.shape} must share the "
+        "image grid (they reuse the same coordinates)"
+    )
+
     bmode_values = bmode_to_uint8(bmode)[np.newaxis]  # (1, z, x)
     bmode_focused_values = bmode_to_uint8(bmode_focused)[np.newaxis]
     sos_values = sos_map[np.newaxis]  # (1, z, x)
@@ -156,6 +163,8 @@ def convert_sample(sample: dict, output_path: Path) -> None:
         scan=scan,
         metadata=metadata,
         metrics=metrics,
+        # In this zea version the probe (incl. probe_geometry) is passed here, not
+        # in `scan`; the old `probe_name=` argument is no longer accepted.
         probe={"name": "Simulated 10L4 Transducer", "probe_geometry": probe_geometry},
         description="NV-Raw2Insights-US FSA phantom simulation (simulated in k-Wave)",
         overwrite=True,

--- a/examples/nv-raw2insights-us/convert.py
+++ b/examples/nv-raw2insights-us/convert.py
@@ -29,6 +29,7 @@ os.environ.setdefault("KERAS_BACKEND", "jax")
 import numpy as np
 from datasets import load_dataset
 from zea import File
+from zea.beamform.pixelgrid import cartesian_pixel_grid
 from zea.display import to_8bit
 from zea.func.ultrasound import log_compress
 
@@ -45,10 +46,23 @@ def bmode_to_uint8(bmode: np.ndarray, dynamic_range_db: float = 60.0) -> np.ndar
     )
 
 
-def extent_to_openh(ext: np.ndarray, scale: float) -> np.ndarray:
-    """[x_min, x_max, z_max, z_min] -> openh-rf [xmin, xmax, 0, 0, zmin, zmax]."""
+def coords_from_extent(
+    ext: np.ndarray, scale: float, grid_size_z: int, grid_size_x: int
+) -> np.ndarray:
+    """Source extent -> per-pixel Cartesian coordinates for the openh-rf spec.
+
+    The openh-rf (zea) Map spec stores per-pixel positions, not a bounding box:
+    `coordinates` of shape (grid_size_z, grid_size_x, 3) in metres, last axis
+    [x, y, z]. The source extent is `[x_min, x_max, z_max, z_min]` in `scale`
+    units (mm for B-modes, m for the SoS map); `scale` converts it to metres.
+    """
     x_min, x_max, z_max, z_min = np.asarray(ext, dtype=np.float64) * scale
-    return np.array([x_min, x_max, 0.0, 0.0, z_min, z_max], dtype=np.float32)
+    return cartesian_pixel_grid(
+        xlims=(x_min, x_max),
+        zlims=(z_min, z_max),
+        grid_size_x=grid_size_x,
+        grid_size_z=grid_size_z,
+    ).astype(np.float32)
 
 
 def convert_sample(sample: dict, output_path: Path) -> None:
@@ -68,42 +82,46 @@ def convert_sample(sample: dict, output_path: Path) -> None:
     ]  # [1, n_tx, n_ax, n_el, 2]
 
     probe_geometry = elpos.T
-    bmode_extent = extent_to_openh(sample["bmode_extent"], scale=1e-3)
-    sos_extent = extent_to_openh(sample["sound_speed_extent"], scale=1.0)
 
-    bmode_values = bmode_to_uint8(bmode)[np.newaxis]
+    bmode_values = bmode_to_uint8(bmode)[np.newaxis]  # (1, z, x)
     bmode_focused_values = bmode_to_uint8(bmode_focused)[np.newaxis]
-    sos_values = sos_map[np.newaxis]
+    sos_values = sos_map[np.newaxis]  # (1, z, x)
     seg_values = np.stack([seg_map == 0, seg_map == 1], axis=-1)[
-        np.newaxis, :, :, np.newaxis, :
-    ]
+        np.newaxis
+    ]  # (1, z, x, 2)
+
+    # Per-pixel coordinate grids (z, x, 3), shared by the B-mode/segmentation
+    # (same image grid) and computed separately for the coarser SoS map.
+    nz_b, nx_b = bmode_values.shape[1], bmode_values.shape[2]
+    nz_s, nx_s = sos_values.shape[1], sos_values.shape[2]
+    bmode_coords = coords_from_extent(sample["bmode_extent"], 1e-3, nz_b, nx_b)
+    sos_coords = coords_from_extent(sample["sound_speed_extent"], 1.0, nz_s, nx_s)
 
     data = {
         "raw_data": raw_data,
         "image": {
             "values": bmode_values,
-            "extent": bmode_extent,
+            "coordinates": bmode_coords,
             "description": "B-mode (DAS, c=1540 m/s)",
         },
         "bmode_focused": {
             "values": bmode_focused_values,
-            "extent": bmode_extent,
+            "coordinates": bmode_coords,
             "description": "B-mode (DBUA aberration-corrected)",
         },
         "sos_map": {
             "values": sos_values,
-            "extent": sos_extent,
+            "coordinates": sos_coords,
             "unit": "m/s",
         },
         "segmentation": {
             "values": seg_values,
             "labels": np.array(["background", "inclusion"], dtype=np.str_),
-            "extent": bmode_extent,
+            "coordinates": bmode_coords,
         },
     }
 
     scan = {
-        "probe_geometry": probe_geometry,
         "sampling_frequency": float(sample["fs"]),
         "center_frequency": float(sample["fc"]),
         "demodulation_frequency": float(sample["fd"]),
@@ -138,7 +156,7 @@ def convert_sample(sample: dict, output_path: Path) -> None:
         scan=scan,
         metadata=metadata,
         metrics=metrics,
-        probe_name="Simulated 10L4 Transducer",
+        probe={"name": "Simulated 10L4 Transducer", "probe_geometry": probe_geometry},
         description="NV-Raw2Insights-US FSA phantom simulation (simulated in k-Wave)",
         overwrite=True,
     ).close()
@@ -165,9 +183,9 @@ def main():
 
     with File(str(args.output)) as f:
         print(f"Data keys: {list(f.data)}")
-        print(f"Scan parameters: {f.scan()}")
-        print(f"Metadata: {f.metadata()}")
-        print(f"Metrics: {f.metrics()}")
+        print(f"Scan parameters: {f.scan}")
+        print(f"Metadata: {f.metadata}")
+        print(f"Metrics: {f.metrics}")
 
 
 if __name__ == "__main__":

--- a/examples/nv-raw2insights-us/pipeline.yaml
+++ b/examples/nv-raw2insights-us/pipeline.yaml
@@ -1,12 +1,18 @@
+# Reconstruction pipeline recipe for the NV-Raw2Insights-US example.
+#
+# This file is written by reconstruct.py (pipeline.to_yaml) as a shareable
+# artifact — the pipeline is defined in code, not loaded from here. It records
+# the DAS -> envelope -> normalize -> log-compress operation chain so the recipe
+# can be inspected or reused; the acquisition/grid parameters live in code.
+
 pipeline:
-    operations:
-    -   name: beamform
-        params:
-            num_patches: 200
-    - envelope_detect
-    -   name: normalize
-        params:
-            output_range:
-            - 0.0
-            - 1.0
-    - log_compress
+  operations:
+    - name: beamform
+      params:
+        beamformer: delay_and_sum
+        num_patches: 200
+    - name: envelope_detect
+    - name: normalize
+      params:
+        output_range: [0.0, 1.0]
+    - name: log_compress

--- a/examples/nv-raw2insights-us/reconstruct.py
+++ b/examples/nv-raw2insights-us/reconstruct.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 """Beamform an openh-rf HDF5 sample produced by convert.py.
 
-Loads raw IQ + scan from the file via zea.File, builds the reconstruction
-pipeline inline (DAS -> envelope -> normalize -> log-compress), saves it to
-pipeline.yaml for reuse, and renders a 7-panel figure (IQ energy, stored DAS
-B-mode, DBUA B-mode, zea-reconstructed B-mode, zea SoS-corrected B-mode, speed
-of sound, segmentation).
+Shows how to go from raw channel data to a B-mode entirely in code with zea:
+build the acquisition parameters and the DAS -> envelope -> normalize ->
+log-compress pipeline inline, beamform `raw_data`, and render a 7-panel figure
+(IQ magnitude, stored DAS B-mode, stored DBUA B-mode, zea-reconstructed B-mode,
+speed-of-sound map, zea SoS-corrected B-mode, segmentation overlay). The pipeline
+is also saved to pipeline.yaml as a shareable artifact, but nothing here loads it.
 
 This is the reference reconstruction / data-validation script for the
 submission: it reproduces a representative B-mode from the raw channel data,
@@ -24,7 +25,6 @@ from pathlib import Path
 # bare `uv run` without first exporting KERAS_BACKEND. An explicit value wins.
 os.environ.setdefault("KERAS_BACKEND", "jax")
 
-import keras
 import matplotlib
 
 matplotlib.use("Agg")
@@ -39,9 +39,12 @@ DEFAULT_OUTPUT = Path("nv_raw2insights_us_reconstructed.png")
 DEFAULT_PIPELINE = HERE / "pipeline.yaml"
 
 
-def ext_to_imshow_mm(ext):
-    """openh-rf [xmin, xmax, ymin, ymax, zmin, zmax] (m) -> mpl [left, right, bottom, top] (mm)."""
-    return [ext[0] * 1e3, ext[1] * 1e3, ext[5] * 1e3, ext[4] * 1e3]
+def coords_to_imshow_mm(coords):
+    """openh-rf per-pixel coordinates (z, x, 3), last axis [x, y, z] in metres
+    -> mpl imshow extent [left, right, bottom, top] in mm."""
+    x = coords[..., 0]
+    z = coords[..., 2]
+    return [x.min() * 1e3, x.max() * 1e3, z.max() * 1e3, z.min() * 1e3]
 
 
 def main():
@@ -52,36 +55,44 @@ def main():
         "--pipeline",
         type=Path,
         default=DEFAULT_PIPELINE,
-        help="Path to write the saved pipeline YAML",
+        help="Path to write the saved pipeline recipe (YAML)",
     )
     args = parser.parse_args()
 
     if not args.input.exists():
-        raise FileNotFoundError(
-            f"{args.input} not found. Run convert.py first."
-        )
+        raise FileNotFoundError(f"{args.input} not found. Run convert.py first.")
 
     zea.init_device()
 
     with zea.File(str(args.input)) as f:
-        probe = f.probe()
-        scan = f.scan()
         raw = f.data.raw_data[:]
         img = f.data.image.values[:]
-        img_ext = f.data.image.extent[:]
+        img_coords = f.data.image.coordinates[:]
         focused = f.data.bmode_focused.values[:]
-        focused_ext = f.data.bmode_focused.extent[:]
+        focused_coords = f.data.bmode_focused.coordinates[:]
         sos = f.data.sos_map.values[:]
-        sos_ext = f.data.sos_map.extent[:]
+        sos_coords = f.data.sos_map.coordinates[:]
         seg = f.data.segmentation.values[:]
-        seg_ext = f.data.segmentation.extent[:]
         labels = f.data.segmentation.labels.asstr()[:]
-        phase_err = f.metrics().common_midpoint_phase_error
+        phase_err = f.metrics.common_midpoint_phase_error
+
+        # Acquisition parameters straight from the file. We only override the
+        # reconstruction grid, derived from the stored B-mode's coordinates so
+        # the result lines up with it (no hard-coded numbers, no config file).
+        nz, nx = img_coords.shape[0], img_coords.shape[1]
+        params = f.load_parameters(
+            grid_size_x=nx,
+            grid_size_z=nz,
+            xlims=[float(img_coords[..., 0].min()), float(img_coords[..., 0].max())],
+            zlims=[float(img_coords[..., 2].min()), float(img_coords[..., 2].max())],
+            n_ch=raw.shape[-1],          # 2 = baseband IQ
+            selected_transmits="all",
+        )
 
     print(f"raw_data: {raw.shape}")
 
-    # DAS -> envelope -> normalize -> log-compress. Saved to pipeline.yaml so the
-    # same chain can be reused without code (zea.Pipeline.from_path).
+    # The reconstruction pipeline, defined in code (DAS -> envelope -> normalize
+    # -> log-compress). Saved to pipeline.yaml as a shareable recipe.
     pipeline = zea.Pipeline(
         operations=[
             Beamform(
@@ -94,34 +105,28 @@ def main():
         ]
     )
     pipeline.to_yaml(str(args.pipeline))
-    print(f"Saved pipeline to {args.pipeline}")
-    params = pipeline.prepare_parameters(probe, scan)
-    outputs = pipeline(**{pipeline.key: raw}, **params)
-    recon = keras.ops.convert_to_numpy(outputs[pipeline.output_key])[0]
-    grid = keras.ops.convert_to_numpy(params["grid"])  # (nz, nx, 3)
-    recon_ext = [
-        grid[0, 0, 0] * 1e3,
-        grid[0, -1, 0] * 1e3,
-        grid[-1, 0, 2] * 1e3,
-        grid[0, 0, 2] * 1e3,
-    ]
+    print(f"Saved pipeline recipe to {args.pipeline}")
+
+    inputs = pipeline.prepare_parameters(params)
+    recon = np.array(pipeline(data=raw, **inputs)["data"])[0]
+    recon_ext = [v * 1e3 for v in params.extent_imshow]  # metres -> mm
     print(f"Reconstructed: {recon.shape}")
 
-    # Reconstruct with SoS correction
-    print(f"sos shape: {sos.shape}")
-    # Handle different possible sos shapes: (frames, nz, nx) or (frames, nz, nx, 1)
+    # SoS-corrected reconstruction: feed the ground-truth sound-speed map (on its
+    # own coarser grid) to the beamformer's heterogeneous-medium mode. This is
+    # valid here because the acquisition is full synthetic aperture (multistatic).
     sos_frame = sos[0] if sos.ndim == 3 else sos[0, :, :, 0]
-    nz_sos, nx_sos = sos_frame.shape[0], sos_frame.shape[1]
-    sos_grid_x = np.linspace(sos_ext[0], sos_ext[1], nx_sos, dtype=np.float32)
-    sos_grid_z = np.linspace(sos_ext[4], sos_ext[5], nz_sos, dtype=np.float32)
-
-    params_sos = params.copy()
-    params_sos["sos_map"] = sos_frame
-    params_sos["sos_grid_x"] = sos_grid_x
-    params_sos["sos_grid_z"] = sos_grid_z
-    outputs_sos = pipeline(**{pipeline.key: raw}, **params_sos)
-
-    recon_sos = keras.ops.convert_to_numpy(outputs_sos[pipeline.output_key])[0]
+    sos_grid_x = np.ascontiguousarray(sos_coords[0, :, 0], dtype=np.float32)
+    sos_grid_z = np.ascontiguousarray(sos_coords[:, 0, 2], dtype=np.float32)
+    recon_sos = np.array(
+        pipeline(
+            data=raw,
+            sos_map=sos_frame,
+            sos_grid_x=sos_grid_x,
+            sos_grid_z=sos_grid_z,
+            **inputs,
+        )["data"]
+    )[0]
     print(f"Reconstructed with SoS correction: {recon_sos.shape}")
 
     fig, axes = plt.subplots(1, 7, figsize=(30, 5))
@@ -136,33 +141,32 @@ def main():
     axes[0].set_ylabel("Axial sample")
 
     # 2: Stored B-mode (DAS)
-    axes[1].imshow(img[0], aspect="auto", cmap="gray", extent=ext_to_imshow_mm(img_ext))
+    axes[1].imshow(
+        img[0], aspect="auto", cmap="gray", extent=coords_to_imshow_mm(img_coords)
+    )
     axes[1].set_title(f"B-mode (DAS, stored)\nimage: {img.shape}")
     axes[1].set_xlabel("Lateral [mm]")
     axes[1].set_ylabel("Depth [mm]")
 
     # 3: Stored DBUA
     axes[2].imshow(
-        focused[0], aspect="auto", cmap="gray", extent=ext_to_imshow_mm(focused_ext)
+        focused[0], aspect="auto", cmap="gray", extent=coords_to_imshow_mm(focused_coords)
     )
     axes[2].set_title(f"B-mode (DBUA, stored)\nbmode_focused: {focused.shape}")
     axes[2].set_xlabel("Lateral [mm]")
     axes[2].set_ylabel("Depth [mm]")
 
     # 4: zea-reconstructed B-mode (DAS pipeline on raw_data)
-    stored_ext = ext_to_imshow_mm(img_ext)
     axes[3].imshow(
         recon, aspect="auto", cmap="gray", vmin=-60, vmax=0, extent=recon_ext
     )
-    axes[3].set_xlim(stored_ext[0], stored_ext[1])
-    axes[3].set_ylim(stored_ext[2], stored_ext[3])
     axes[3].set_title(f"B-mode (DAS, zea)\nreconstructed: {recon.shape}")
     axes[3].set_xlabel("Lateral [mm]")
     axes[3].set_ylabel("Depth [mm]")
 
     # 5: SOS map
     im = axes[4].imshow(
-        sos[0], aspect="auto", cmap="hot", extent=ext_to_imshow_mm(sos_ext)
+        sos[0], aspect="auto", cmap="hot", extent=coords_to_imshow_mm(sos_coords)
     )
     plt.colorbar(im, ax=axes[4], label="m/s")
     axes[4].set_title(f"Speed of sound\nsos_map: {sos.shape}")
@@ -173,22 +177,20 @@ def main():
     axes[5].imshow(
         recon_sos, aspect="auto", cmap="gray", vmin=-60, vmax=0, extent=recon_ext
     )
-    axes[5].set_xlim(stored_ext[0], stored_ext[1])
-    axes[5].set_ylim(stored_ext[2], stored_ext[3])
     axes[5].set_title(f"B-mode (DAS + SoS, zea)\nreconstructed: {recon_sos.shape}")
     axes[5].set_xlabel("Lateral [mm]")
     axes[5].set_ylabel("Depth [mm]")
 
     # 7: Segmentation overlaid on focused (DBUA) B-mode
     axes[6].imshow(
-        focused[0], aspect="auto", cmap="gray", extent=ext_to_imshow_mm(focused_ext)
+        focused[0], aspect="auto", cmap="gray", extent=coords_to_imshow_mm(focused_coords)
     )
     axes[6].imshow(
-        seg[0, :, :, 0, 1],
+        seg[0, :, :, 1],  # (n_frames, z, x, n_labels); label 1 = inclusion
         aspect="auto",
         cmap="Reds",
         alpha=0.4,
-        extent=ext_to_imshow_mm(seg_ext),
+        extent=coords_to_imshow_mm(img_coords),
     )
     axes[6].set_title(f"Segmentation on DBUA\nlabels: {list(labels)}")
     axes[6].set_xlabel("Lateral [mm]")

--- a/examples/nv-raw2insights-us/reconstruct.py
+++ b/examples/nv-raw2insights-us/reconstruct.py
@@ -25,6 +25,7 @@ from pathlib import Path
 # bare `uv run` without first exporting KERAS_BACKEND. An explicit value wins.
 os.environ.setdefault("KERAS_BACKEND", "jax")
 
+import keras
 import matplotlib
 
 matplotlib.use("Agg")
@@ -108,7 +109,13 @@ def main():
     print(f"Saved pipeline recipe to {args.pipeline}")
 
     inputs = pipeline.prepare_parameters(params)
-    recon = np.array(pipeline(data=raw, **inputs)["data"])[0]
+    # keras.ops.convert_to_numpy (not np.array) so the output tensor is pulled
+    # off the device regardless of backend — e.g. PyTorch needs an explicit
+    # .cpu(), which np.array would not do.
+    recon = keras.ops.convert_to_numpy(pipeline(data=raw, **inputs)["data"])[0]
+    # The reconstruction grid was derived from img_coords above, so its mpl
+    # extent equals coords_to_imshow_mm(img_coords) — params.extent_imshow is
+    # just the same thing zea already computed for us.
     recon_ext = [v * 1e3 for v in params.extent_imshow]  # metres -> mm
     print(f"Reconstructed: {recon.shape}")
 
@@ -118,7 +125,7 @@ def main():
     sos_frame = sos[0] if sos.ndim == 3 else sos[0, :, :, 0]
     sos_grid_x = np.ascontiguousarray(sos_coords[0, :, 0], dtype=np.float32)
     sos_grid_z = np.ascontiguousarray(sos_coords[:, 0, 2], dtype=np.float32)
-    recon_sos = np.array(
+    recon_sos = keras.ops.convert_to_numpy(
         pipeline(
             data=raw,
             sos_map=sos_frame,
@@ -185,8 +192,11 @@ def main():
     axes[6].imshow(
         focused[0], aspect="auto", cmap="gray", extent=coords_to_imshow_mm(focused_coords)
     )
+    # seg is (n_frames, z, x, n_labels); pick the "inclusion" channel by name
+    # rather than a hard-coded index, so it stays correct if label order changes.
+    inclusion_idx = list(labels).index("inclusion")
     axes[6].imshow(
-        seg[0, :, :, 1],  # (n_frames, z, x, n_labels); label 1 = inclusion
+        seg[0, :, :, inclusion_idx],
         aspect="auto",
         cmap="Reds",
         alpha=0.4,

--- a/uv.lock
+++ b/uv.lock
@@ -2879,7 +2879,7 @@ requires-dist = [
     { name = "tensorflow", marker = "extra == 'tf'" },
     { name = "tensorflow", extras = ["and-cuda"], marker = "extra == 'tf-gpu'" },
     { name = "torch", marker = "extra == 'torch'" },
-    { name = "zea", specifier = "==0.1.0a0" },
+    { name = "zea", specifier = "==0.1.0a1" },
 ]
 provides-extras = ["test", "gpu", "torch", "tf", "tf-gpu"]
 
@@ -5013,7 +5013,7 @@ wheels = [
 
 [[package]]
 name = "zea"
-version = "0.1.0a0"
+version = "0.1.0a1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "decorator" },
@@ -5041,9 +5041,9 @@ dependencies = [
     { name = "wandb" },
     { name = "wget" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/73/dc6d31a6a5f35bfcc64fb05187d822d4d79eff1d9993ae576ff809b59e97/zea-0.1.0a0.tar.gz", hash = "sha256:e42c6e0695344501b4f2ae745a58b861ffb52eb13519e68ed8668160b48d6020", size = 407014, upload-time = "2026-05-19T11:55:22.523Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/cf/ed2a3023d5626d900f2b4ef9f01003ccdca1233e108095aee1ce853ab66d/zea-0.1.0a1.tar.gz", hash = "sha256:1e5b485db4dd51c64167198c20bd2964540661ccc79278838f66b59dc15f6e52", size = 451814, upload-time = "2026-06-04T07:07:16.136Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/46/91e295d317fbed4ca14c55ef1694036320039d8d8221b9580a3410d17632/zea-0.1.0a0-py3-none-any.whl", hash = "sha256:ea33cc0f4c9c412931e9c1ca142ddff0de487e118d4be62134cf12ebff63b5fe", size = 465033, upload-time = "2026-05-19T11:55:20.398Z" },
+    { url = "https://files.pythonhosted.org/packages/70/8a/221805a5cde5c5b5bb14b76af8c2bb1030815bdc0f19fba4e42256e3d55e/zea-0.1.0a1-py3-none-any.whl", hash = "sha256:94b8f55502b0d9c9b4fc3e7af14b2e103822873f604bc359f1ea26fa524f2726", size = 513758, upload-time = "2026-06-04T07:07:14.586Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
 ## What & why

  Bumps zea to the openh-rf data spec (SHA-pinned) and migrates the
  `nv-raw2insights-us` example from the per-map `extent` bounding box to per-pixel
  `coordinates`, which that spec requires (it no longer accepts `extent` for maps).

  ## Changes

  - **`pyproject.toml` / `uv.lock`** — zea pinned to
    `git+https://github.com/tue-bmd/zea.git@870e322…` (point-based coordinates spec).
  - **`convert.py`** — `coords_from_extent` builds per-pixel coordinate grids with
    `zea.beamform.pixelgrid.cartesian_pixel_grid`; `image`, `bmode_focused`,
    `sos_map`, `segmentation` now emit `coordinates` `(z, x, 3)` (metres, `[x,y,z]`)
    instead of `extent`. Segmentation values are 4-D `(1, z, x, n_labels)`.
  - **`reconstruct.py`** — reads `.coordinates`; derives imshow extents and the SoS
    reconstruction grid from coordinates; segmentation indexing fixed for 4-D.
  - **`README.md`** — data-card feature table + format notes updated to coordinates.

  ## Verification

  End-to-end against the pinned zea: `convert.py` writes a file where every map
  carries `coordinates` and no `extent` (validates under the openh-rf `FileSpec`),
  and `reconstruct.py` renders the 7-panel figure correctly (cysts resolved; SoS
  and segmentation panels positioned from coordinates).

  ---
  Note: this PR pins zea to an unreleased branch SHA