### PR TITLE
Update docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ We aim to curate **20,000+** real and synthetic channel capture measurements spa
 
 1. **Review the RFP** — Read the [Request for Proposals](assets/OpenH-RF%20Request%20for%20Proposals%20(RFP).pdf) for technical scope, eligibility and evaluation criteria.
 2. **Submit a Proposal** — Prepare a concise proposal (≤ 5 pages) describing your dataset, collection methodology and target tasks. Submit to [this Google Form](https://forms.gle/tqiqYSnnar1AekB19).
-3. **Contribute Data** — Once approved, prepare your dataset in the OpenH-RF format, implemented in [`zea`](https://github.com/tue-bmd/zea) as documented [here](https://zea--358.org.readthedocs.build/en/358/data-acquisition.html), along with a datacard specifying the CC BY 4.0 license. Approved contributors are given a dedicated shared storage location (S3 or Google Drive) for delivery and a Discord channel for coordination.
+3. **Contribute Data** — Once approved, prepare your dataset in the OpenH-RF format, implemented in [`zea`](https://github.com/tue-bmd/zea) as documented [here](https://zea.readthedocs.io/en/v0.1.0a1/data-acquisition.html), along with a datacard specifying the CC BY 4.0 license. Approved contributors are given a dedicated shared storage location (S3 or Google Drive) for delivery and a Discord channel for coordination.
 4. **Co-author the Release** — Approved contributions are included in the public dataset and foundation model release — contributors are named co-authors in related publications upon project completion.
 
 ## Key Dates
@@ -47,7 +47,7 @@ We aim to curate **20,000+** real and synthetic channel capture measurements spa
 
 ## Dataset Format
 
-The OpenH-RF format is implemented using the [`zea`](https://github.com/tue-bmd/zea) ultrasound toolbox. See the `zea` documentation for the [data specification](https://zea--358.org.readthedocs.build/en/358/data-acquisition.html). Each example below writes a single `.hdf5` file using `zea` and demonstrates the fields expected for a given modality:
+The OpenH-RF format is implemented using the [`zea`](https://github.com/tue-bmd/zea) ultrasound toolbox. See the `zea` documentation for the [data specification](https://zea.readthedocs.io/en/v0.1.0a1/data-acquisition.html). Each example below writes a single `.hdf5` file using `zea` and demonstrates the fields expected for a given modality:
 
 | Example | Modality |
 |---------|----------|

--- a/examples/nv-raw2insights-us/README.md
+++ b/examples/nv-raw2insights-us/README.md
@@ -31,7 +31,7 @@ submission files** are:
 
 | File | Role |
 |------|------|
-| `*.hdf5` | Acquisition(s) in [`zea` file format](https://zea.readthedocs.io/en/latest/data-acquisition.html) (one file per acquisition) |
+| `*.hdf5` | Acquisition(s) in [`zea` file format](https://zea.readthedocs.io/en/v0.1.0a1/data-acquisition.html) (one file per acquisition) |
 | [`reconstruct.py`](reconstruct.py) | Reference reconstruction → `.png`, driven by a `zea.Pipeline` |
 | [`pipeline.yaml`](pipeline.yaml) | The saved reconstruction pipeline |
 | `README.md` | This data card |
@@ -98,7 +98,7 @@ tissue segmentation from raw channel data.
 
 ## Dataset Format
 
-Submitted in the [`zea` file format](https://zea.readthedocs.io/en/latest/data-acquisition.html)
+Submitted in the [`zea` file format](https://zea.readthedocs.io/en/v0.1.0a1/data-acquisition.html)
 (one HDF5 file per acquisition). `convert.py` maps the source HF Arrow features
 onto `zea` groups: raw IQ channel data, stored B-modes, the sound-speed map, the
 segmentation, scan parameters, and the per-sample phase-error metric. B-modes are

--- a/examples/templates/README.md
+++ b/examples/templates/README.md
@@ -8,4 +8,4 @@ The examples in this directory are **templates**, intended to provide a starting
 
 For most templates, we have included dummy data to indicate the correct data types and tensor shapes for the variables supported by the `zea` data format. In the Verasonics template, we have included real Verasonics data saved in
 .mat format from the Verasonics matlab workspace. For more information on the data format, please refer to the 
-[`zea` data format reference](https://zea--358.org.readthedocs.build/en/358/data-acquisition.html#zea-data-format-reference).
+[`zea` data format reference](https://zea.readthedocs.io/en/v0.1.0a1/data-acquisition.html#zea-data-format-reference).

--- a/uv.lock
+++ b/uv.lock
@@ -2879,7 +2879,7 @@ requires-dist = [
     { name = "tensorflow", marker = "extra == 'tf'" },
     { name = "tensorflow", extras = ["and-cuda"], marker = "extra == 'tf-gpu'" },
     { name = "torch", marker = "extra == 'torch'" },
-    { name = "zea", specifier = "==0.1.0a0" },
+    { name = "zea", specifier = "==0.1.0a1" },
 ]
 provides-extras = ["test", "gpu", "torch", "tf", "tf-gpu"]
 
@@ -5013,7 +5013,7 @@ wheels = [
 
 [[package]]
 name = "zea"
-version = "0.1.0a0"
+version = "0.1.0a1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "decorator" },
@@ -5041,9 +5041,9 @@ dependencies = [
     { name = "wandb" },
     { name = "wget" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/73/dc6d31a6a5f35bfcc64fb05187d822d4d79eff1d9993ae576ff809b59e97/zea-0.1.0a0.tar.gz", hash = "sha256:e42c6e0695344501b4f2ae745a58b861ffb52eb13519e68ed8668160b48d6020", size = 407014, upload-time = "2026-05-19T11:55:22.523Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/cf/ed2a3023d5626d900f2b4ef9f01003ccdca1233e108095aee1ce853ab66d/zea-0.1.0a1.tar.gz", hash = "sha256:1e5b485db4dd51c64167198c20bd2964540661ccc79278838f66b59dc15f6e52", size = 451814, upload-time = "2026-06-04T07:07:16.136Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/46/91e295d317fbed4ca14c55ef1694036320039d8d8221b9580a3410d17632/zea-0.1.0a0-py3-none-any.whl", hash = "sha256:ea33cc0f4c9c412931e9c1ca142ddff0de487e118d4be62134cf12ebff63b5fe", size = 465033, upload-time = "2026-05-19T11:55:20.398Z" },
+    { url = "https://files.pythonhosted.org/packages/70/8a/221805a5cde5c5b5bb14b76af8c2bb1030815bdc0f19fba4e42256e3d55e/zea-0.1.0a1-py3-none-any.whl", hash = "sha256:94b8f55502b0d9c9b4fc3e7af14b2e103822873f604bc359f1ea26fa524f2726", size = 513758, upload-time = "2026-06-04T07:07:14.586Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
We are now hosting docs for our latest pre-release at https://zea.readthedocs.io/en/v0.1.0a1/

This PR updates docs links to point there, to make sure that the docs info matches the zea version installed by the pyproject.toml.

I also noticed that the zea version in the uv.lock was still the old version, so ran `uv lock` to update that.