### PR TITLE
Add openh-rf-submission-eval Claude skill + AGENTS.md

### DIFF
--- a/.claude/skills/openh-rf-submission-eval/.gitignore
+++ b/.claude/skills/openh-rf-submission-eval/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+*.pyo
+.DS_Store
+*.skill

--- a/.claude/skills/openh-rf-submission-eval/README.md
+++ b/.claude/skills/openh-rf-submission-eval/README.md
@@ -1,0 +1,94 @@
+# openh-rf-submission-eval
+
+A Claude skill for evaluating submissions to the [OpenH-RF](https://github.com/open-h/OpenH-RF) open ultrasound channel-data initiative against the RFP and submission guide.
+
+## What it does
+
+Given a contributor submission (zea file + data card + pipeline), the skill produces a structured acceptance report covering seven independent evaluation dimensions:
+
+1. **Format compliance** — is the file actually in zea format?
+2. **Reconstruction** — does the pipeline run and produce a sensible B-mode image, free of pipeline-induced artifacts?
+3. **Metadata sufficiency** — can a stranger reconstruct from this without contacting the contributor?
+4. **Data card** — complete per template, no placeholder text, no PHI?
+5. **Documentation & clarity** — would a first-time user hit walls?
+6. **Licensing & IP** — confirmed CC BY 4.0, no encumbrances?
+7. **Ethics & compliance** — tier-appropriate (HIPAA Safe Harbor for human data, ARRIVE 2.0 for animal, etc.)
+
+Each dimension is decoupled and designed for parallel sub-agent execution in Claude Code. Each opens with a short persona block (e.g., "data-format auditor", "research compliance officer") that sets the disposition for that dimension.
+
+**The accepted proposal is a required input.** The skill reads it first and checks the submission *against* it: content promised but missing is flagged as under-delivery, and anything added beyond the proposal must be documented in the data card. The goal is a submission that stays aligned with what was proposed and accepted — additions are welcome, but they have to be written down. Without the proposal the skill cannot assess alignment or honor negotiated carve-outs.
+
+## Layout
+
+```
+openh-rf-submission-eval/
+├── SKILL.md                  # Orchestration: workflow, verdict logic, auto-fix rules
+├── references/
+│   ├── rfp-summary.md        # OpenH-RF RFP scope and tiers
+│   ├── data-card-template.md # Canonical data card template
+│   ├── zea-format-notes.md   # zea file format reference
+│   ├── phi-checklist.md      # HHS Safe Harbor 18 identifiers
+│   ├── imaging-artifacts.md  # Acquisition-induced vs pipeline-induced artifact taxonomy
+│   └── dimensions/
+│       ├── 01-format.md
+│       ├── 02-reconstruction.md
+│       ├── 03-metadata.md
+│       ├── 04-data-card.md
+│       ├── 05-documentation.md
+│       ├── 06-licensing.md
+│       └── 07-ethics.md
+└── scripts/
+    ├── pipeline_template.py  # Default DAS->envelope->log B-mode pipeline (auto-fix)
+    └── judge_bmode.py        # Objective sanity checks on a reconstructed image
+```
+
+## How to install
+
+### As a Claude Code skill
+
+Clone this repo into your Claude Code skills directory:
+
+```bash
+git clone <repo-url> ~/.claude/skills/openh-rf-submission-eval
+```
+
+(Or your project-local `.claude/skills/` if you prefer.)
+
+### As a packaged .skill file
+
+```bash
+# Using the skill-creator packaging script
+python -m scripts.package_skill /path/to/openh-rf-submission-eval
+# Produces openh-rf-submission-eval.skill, which can be uploaded in Claude.ai
+```
+
+## How to use
+
+Once installed, ask Claude to evaluate a submission:
+
+> "Evaluate this OpenH-RF submission at `/path/to/submission/`"
+>
+> "Can we accept the submission at ~/openh-rf/inbox/example-contributor-2026-06/?"
+
+The skill produces `evaluation_report.md` plus, if applicable, an `autofix/` directory containing auto-generated artifacts (B-mode pipeline, reference image, filled-in data-card fields).
+
+## Verdict rules
+
+- Any `blocker` finding → **Reject — needs resubmission**
+- Any `major` finding → **Accept with revisions**
+- Only `minor`/`info` → **Accept**
+
+## What gets auto-fixed
+
+- Missing B-mode pipeline (generated from `scripts/pipeline_template.py` if metadata is sufficient)
+- Derivable data-card fields (sample count, total size, per-sample feature table)
+- Missing reference B-mode images (rendered once the pipeline works)
+
+What does **not** get auto-fixed: license declarations, consent/IRB status, subject metadata, intended-usage descriptions, known-issues. These require the contributor.
+
+## License
+
+Apache-2.0, matching the OpenH-RF repository — this skill is software. (Note:
+*dataset submissions* evaluated by this skill must be CC BY 4.0, which is the
+data license the initiative requires; that is a separate thing from the license
+of this tool.)

--- a/.claude/skills/openh-rf-submission-eval/SKILL.md
+++ b/.claude/skills/openh-rf-submission-eval/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: openh-rf-submission-eval
+description: Evaluate a submission to the OpenH-RF (open ultrasound channel-data) initiative against the RFP and submission guide. Use this whenever the user wants to review, grade, validate, accept, or QA a proposed contribution to OpenH-RF, OpenH, or any open ultrasound channel/RF dataset — including when they hand over a folder, a Hugging Face link, a zea file, or a data card and ask whether it's ready, whether it meets the bar, what's missing, or whether it can be accepted. Also use when the user wants to auto-fix gaps in a submission, such as generating a missing B-mode pipeline, filling in data-card fields, or rendering a reference reconstruction. Trigger even if the user doesn't say OpenH-RF by name — ultrasound channel data plus a review or intake context is enough.
+---
+
+# OpenH-RF Submission Evaluator
+
+This skill reviews a contributor submission to the OpenH-RF initiative and produces a structured acceptance report. Each evaluation dimension is independent and is designed to be dispatched to a sub-agent in parallel.
+
+## What you're evaluating against
+
+OpenH-RF accepts pre-beamformed ultrasound channel data in the *zea* file format, licensed CC BY 4.0, accompanied by a Hugging Face–style `README.md` (which **is** the data card — Hugging Face renders `README.md` as the dataset landing page; see <https://huggingface.co/docs/hub/datasets-cards>) and a reconstruction pipeline that turns the raw channel data into a B-mode image. **There is exactly one user-facing document: `README.md`. There is no separate `DATA_CARD.md`.** The full requirements live in:
+
+- `references/rfp-summary.md` — RFP scope, tiers, eligibility, timeline
+- `references/data-card-template.md` — exact fields the `README.md` must contain, including the YAML frontmatter HF parses
+- `references/zea-format-notes.md` — what a valid zea file looks like and what fields it must expose
+- `references/phi-checklist.md` — canonical HHS Safe Harbor 18 identifiers (used by dimensions 4 and 7)
+- `references/imaging-artifacts.md` — taxonomy of acquisition-induced vs pipeline-induced image artifacts (used by dimension 2)
+
+Read these as needed. Do not try to hold them all in head — pull them in when a specific dimension calls for it.
+
+## Sub-agent personas
+
+Each dimension file opens with a short **Persona** block — a one-paragraph role and disposition. When dispatching a sub-agent for a dimension, the persona is the framing the sub-agent operates under (e.g., "data-format auditor", "ultrasound imaging engineer", "research compliance officer"). The personas are deliberately lightweight: just enough to set tone and rigor, not a full character. They make findings more memorable across dimensions and help calibrate severity ("the compliance officer flagged …" vs "the reproducibility reviewer flagged …").
+
+Do not invent new personas or stretch them. If a dimension's persona feels wrong for a specific submission, fall back to neutral instruction-following — don't drift.
+
+## The seven evaluation dimensions
+
+A submission is scored on seven independent dimensions. Each has its own checklist file under `references/dimensions/`. The dimensions are deliberately decoupled so they can run in parallel as sub-agents:
+
+1. **Format compliance** (`dimensions/01-format.md`) — Is the data actually in zea format? Do the on-disk fields, shapes, and dtypes match the spec?
+2. **Reconstruction** (`dimensions/02-reconstruction.md`) — Run the contributor's pipeline. Does it produce a sensible B-mode image? This is the most expensive check.
+3. **Metadata sufficiency** (`dimensions/03-metadata.md`) — Are all acquisition hyperparameters (transducer geometry, element count, center frequency, sampling rate, sound speed, transmit sequence, etc.) present and self-consistent? A novice with no contact with the contributor must be able to reconstruct from what's in the file alone.
+4. **Data card** (`dimensions/04-data-card.md`) — `README.md` exists at the dataset root, carries valid HF YAML frontmatter (`license`, `pretty_name`, `task_categories`, `tags`), every template section filled in, no placeholder text, statistics aggregate-only (no PHI).
+5. **Documentation & clarity** (`dimensions/05-documentation.md`) — Can a graduate student who has never seen this data understand what it is, what task it supports, and how to use it within ~15 minutes of reading? This is the "novice user" check, evaluated against the same `README.md` plus the pipeline and reference images.
+6. **Licensing & IP** (`dimensions/06-licensing.md`) — Confirmed CC BY 4.0, no third-party IP encumbrances, consent/IRB status documented.
+7. **Ethics & compliance** (`dimensions/07-ethics.md`) — HIPAA Safe Harbor de-identification for human data, ARRIVE 2.0 for animal, IRB approval where required.
+
+Each dimension file contains its own pass/fail criteria, severity rubric, and what evidence to record.
+
+## Workflow
+
+### Step 1: Locate and inventory the submission
+
+The user will hand you a path (local folder, mounted bucket, HF repo). Before evaluating anything, list what's actually there. Expect roughly:
+
+- One or more `.hdf5` files in *zea* format — the channel data; **each acquisition is a single HDF5 file**, and a submission may contain several
+- `reconstruct.py` — a single runnable script that reconstructs from the raw channel data and outputs a `.png`
+- `pipeline.yaml` — a saved `zea.Pipeline`, **one per track** in the file(s)
+- `README.md` at the dataset root — this **is** the data card (HF renders it as the dataset landing page). Must have YAML frontmatter with `license`, `pretty_name`, `task_categories`, `tags`.
+- `LICENCE` file declaring **CC BY 4.0** (either spelling — the submission guide uses `LICENCE`)
+- 1–2 reference B-mode images (the `.png`(s) `reconstruct.py` produces)
+- Possibly: consent/IRB documentation
+
+This is exactly the deliverable set the submission guide requires: zea `.hdf5` files, `reconstruct.py`, `pipeline.yaml` (one per track), `README.md`, and `LICENCE`. A separate `DATA_CARD.md` is **not** part of the expected layout — if one exists, treat it as a contributor-side artifact to be merged into `README.md` and flag the duplication.
+
+Make an `inventory.json` recording what's present, what's missing, and file sizes. If the inventory is grossly incomplete (e.g., no zea file at all), stop and report — there's nothing to evaluate yet.
+
+**Read the proposal first — it is required.** The accepted proposal is the contract: the submission is evaluated partly on whether it delivers what the contributor said they would deliver. Before dispatching any dimension sub-agents, read the contributor's accepted proposal from the source location (typically a PDF in the submission tree). If it isn't in the submission, ask the user for it. **If no accepted proposal can be produced, stop and mark the evaluation `blocked`** — without it you cannot check alignment or honor any negotiated carve-outs. Extract: declared tier, tasks, the **data types / modalities / quantities promised**, license intent, ethics codes, and **any explicit carve-outs** (things the contributor said they would *not* provide). Carve-outs the steering group accepted at proposal review are **not** failures during evaluation — note them and move on. Each dimension sub-agent prompt must include the carve-out list so they don't double-jeopardy the contributor on something already negotiated.
+
+Common carve-out examples: "3D position information will not be provided", "subject demographics aggregate-only", "annotations limited to N frames per acquisition".
+
+**Step 1b — check the submission against the proposal.** OpenH-RF wants submissions that match what was proposed and accepted, not something materially different. Compare the inventory to the proposal and record three things:
+
+- **Delivered as proposed** — promised content that is present. No finding.
+- **Under-delivered** — content the proposal promised that is missing or materially smaller than promised, and that is *not* an accepted carve-out. This is a `major` finding (route it to the relevant dimension): the contributor should either deliver it or get a carve-out on record. (Missing `raw_data` is always a `blocker` regardless — see below.)
+- **Added beyond the proposal** — content present that the proposal did not mention (extra modalities, tasks, subjects, derived products). This is **not** a reason to reject — additions are welcome — but each addition **must be documented in the data card** (`README.md`). An undocumented addition is a `major` data-card finding ("you included X beyond your proposal; describe it in the data card"). Also note material scope additions for steering-group awareness.
+
+Pass the alignment summary (under-delivered list + added-beyond-proposal list) into the relevant dimension sub-agents alongside the carve-out list.
+
+**Hard requirement — no carve-out applies.** Every OpenH-RF submission **must** include raw pre-beamformed channel capture data (`/data/raw_data` in zea format). This is the core of the dataset and is non-negotiable: a proposal that omits raw channel data does not qualify, and an evaluation that finds `/data/raw_data` missing or empty should mark dimension 1 (Format) `blocker` regardless of what the proposal says.
+
+### Step 2: Dispatch the seven dimension checks in parallel
+
+In Claude Code, spawn one sub-agent per dimension. Each sub-agent:
+- Reads only its own `references/dimensions/0X-*.md`
+- Reads only the submission artifacts relevant to its dimension (the dimension file says which)
+- Returns a structured result: `{dimension, status, severity, findings[], evidence[], suggested_fixes[]}`
+
+`status` is one of: `pass`, `pass_with_notes`, `fail`, `blocked` (couldn't evaluate — usually means a dependency is missing).
+`severity` is `info`, `minor`, `major`, `blocker`. A `blocker` on any dimension means the submission cannot be accepted as-is.
+
+If you're not in an environment with sub-agents, run them serially in the order above — format first (cheap, gates everything else), reconstruction last (most expensive).
+
+### Step 3: Auto-fix the fixable
+
+Several common gaps are fixable without going back to the contributor:
+
+- **Missing B-mode pipeline.** If metadata is sufficient (dimension 3 passed) but `reconstruct.py` / `pipeline.yaml` were not included, generate them. The template is at `scripts/pipeline_template.py` — fill in the acquisition-specific values from the zea file. Standard chain: DAS beamforming → envelope detection (Hilbert) → log compression → normalization. Save the script as `reconstruct.py` and the saved pipeline as `pipeline.yaml` (**one per track**, matching the submission guide), then re-run dimension 2 against it.
+- **Missing or incomplete `README.md` (the data card).** Generate a single `README.md` — never a separate `DATA_CARD.md` — with HF YAML frontmatter (`license`, `pretty_name`, `task_categories`, `tags`) followed by the data-card sections from `references/data-card-template.md`. Auto-populate the derivable fields (number of samples, total size on disk, per-sample feature table, file format, dataset characterization) from the zea file. Flag the rest as `REQUIRES_CONTRIBUTOR` rather than silently filling. If a `DATA_CARD.md` already exists, merge its content into `README.md` and mark the standalone file for removal.
+- **Missing reference B-mode images.** Once you have a working pipeline, render 1–2 representative frames and add them to the submission. Link them from the `Data Validation` section of the `README.md`.
+
+Never auto-fix: license declarations, consent/IRB status, subject metadata, intended-usage descriptions, known-issues. These require the contributor.
+
+### Step 4: Render the acceptance report
+
+Produce `evaluation_report.md` with this exact structure:
+
+```
+# OpenH-RF Submission Evaluation: <submission name>
+
+**Overall verdict:** Accept | Accept with revisions | Reject — needs resubmission
+**Evaluated on:** <date>
+**Reviewer:** Claude (automated)
+
+## Executive scorecard
+
+| # | Category | Result |
+|---|---|---|
+| 1 | Format compliance | ✅ PASS  /  ❌ FAIL |
+| 2 | Reconstruction & image quality | ✅ PASS  /  ❌ FAIL |
+| 3 | Metadata sufficiency | ✅ PASS  /  ❌ FAIL |
+| 4 | Data card | ✅ PASS  /  ❌ FAIL |
+| 5 | Documentation & clarity | ✅ PASS  /  ❌ FAIL |
+| 6 | Licensing & IP | ✅ PASS  /  ❌ FAIL |
+| 7 | Ethics & compliance | ✅ PASS  /  ❌ FAIL |
+
+**Pass/fail rule per category:** a category is PASS if its severity is `info` or `minor`. It is FAIL if any finding in that category is `major` or `blocker`. This is binary by design — the detailed severity is in the per-dimension section below for reviewers who need it, but the contributor sees pass/fail.
+
+## Proposal alignment
+
+| Aspect | Status |
+|---|---|
+| Delivered as proposed | <short summary> |
+| Under-delivered (promised but missing/smaller) | <list, or "none"> |
+| Added beyond proposal (must be documented in data card) | <list, or "none"> |
+| Accepted carve-outs honored | <list, or "none"> |
+
+## Feedback for the contributor
+
+One short paragraph (3–5 sentences) per FAILED category, addressed *to the contributor*, second person, plain language. State what's wrong, why it matters, and the concrete fix. No jargon the contributor wouldn't already know. No restating the persona. No throat-clearing ("Thank you for your submission…").
+
+For PASSED categories: one sentence acknowledging it, only if there's something noteworthy. Most PASSED categories get no feedback paragraph.
+
+Example feedback paragraphs:
+
+> **3. Metadata sufficiency — FAIL.** The zea file is missing the speed-of-sound value used during acquisition, which means a downstream user can't reproduce your beamforming. Add `scan/sound_speed` (m/s) as a top-level attribute, or document it in the data card under "Acquisition system". Also worth double-checking: your sampling rate is recorded as 25 MHz but your center frequency is 7.5 MHz — that's only ~3.3× Nyquist; please confirm this is intentional rather than a unit error.
+
+> **6. Licensing & IP — FAIL.** Your data card says "released for academic research" — this is incompatible with CC BY 4.0, which OpenH-RF requires and which explicitly permits commercial use. Please confirm with your institution's legal team that you can release under CC BY 4.0, then update the License section to state that explicitly. If you cannot, the submission can't be accepted under the current RFP.
+
+## Per-dimension findings (detail for reviewers)
+
+### 1. Format compliance
+**Status:** pass | pass_with_notes | fail | blocked
+**Severity:** info | minor | major | blocker
+**Findings:**
+- ...
+**Evidence:**
+- ...
+**Suggested fixes:**
+- ...
+
+[repeat for each dimension]
+
+## Auto-fixes applied
+- [list of changes made, with file paths]
+
+## Action items for the contributor
+- [ordered list, blockers first, copy from feedback paragraphs above]
+
+## Reference reconstruction
+[Embedded B-mode image(s) produced by the pipeline check]
+```
+
+The verdict rule:
+- Any category FAILS with `blocker` severity → **Reject — needs resubmission**
+- Any category FAILS with `major` severity → **Accept with revisions**
+- All categories PASS → **Accept**
+
+## Writing the contributor feedback paragraphs
+
+The feedback paragraphs are the most-read part of the report. Get them right.
+
+**Voice.** Address the contributor as "you". The data is "your dataset", "your pipeline", "your data card". This is a colleague-to-colleague tone — not formal, not breezy.
+
+**Structure each paragraph as:** (1) what's wrong, in one sentence; (2) why it matters for downstream users or for acceptance, in one sentence; (3) the concrete fix, in one to two sentences. If there are multiple problems in the category, pick the one or two most consequential — don't enumerate every minor issue here (those live in the per-dimension findings below).
+
+**Plain language.** "Your pipeline crashes when the third frame is loaded because the channel-data array is rank-3 instead of rank-4" is good. "Tensor rank mismatch in axis enumeration of the channel acquisition manifold" is bad.
+
+**No persona artifacts.** The compliance officer, the reproducibility reviewer, the imaging engineer — those are framings for the sub-agents, not voices the contributor should see. Feedback paragraphs are written in a single, neutral voice.
+
+**Length.** 3–5 sentences. If you find yourself writing more, you're listing minor findings that should stay in the per-dimension section.
+
+### Step 5: Hand back the report and the auto-fixed artifacts
+
+Place the report next to the submission. If you auto-fixed anything, place those files in an `autofix/` subdirectory alongside the report so the contributor can see exactly what was added.
+
+## Important judgment calls
+
+**"Novice user" means.** A graduate student in medical imaging who has not spoken to the contributor and is reading the data card and pipeline cold. Not a complete beginner — they know what beamforming is. The bar is: can they reconstruct a B-mode image and understand what the data is for, from the artifacts alone, without asking questions.
+
+**Tier weighting is not your problem.** The RFP weights in-vivo human data x100 vs phantom x1, but that's for acceptance-priority decisions at the steering-group level. You evaluate quality and completeness regardless of tier. Note the tier in the report but don't let it change the bar.
+
+**Be specific in findings.** "Data card incomplete" is useless. "Data card section 'Subject Metadata' is empty; spec requires aggregate counts of subjects, age range, sex distribution, and probe model" is actionable. Every finding should be specific enough that the contributor knows exactly what to change.
+
+**Don't reject for stylistic issues.** Markdown formatting, prose quality in the description, choice of variable names in the pipeline — note these as `info`, never `major`. The bar is technical correctness and completeness, not polish.
+
+**When in doubt about scope.** If the submission claims a task not in RFP sections 6.1–6.6, that's `info`, not a failure — the RFP welcomes novel applications. Flag it for steering-group review.

--- a/.claude/skills/openh-rf-submission-eval/references/data-card-template.md
+++ b/.claude/skills/openh-rf-submission-eval/references/data-card-template.md
@@ -1,0 +1,75 @@
+# OpenH-RF data card template (canonical)
+
+Copy of the contributor-facing template. Use this as the ground truth when checking dimension 4.
+
+The data card is delivered as a **single `README.md`** at the dataset root. Hugging Face renders `README.md` as the dataset landing page (<https://huggingface.co/docs/hub/datasets-cards>), so this is the only user-facing document — there is no separate `DATA_CARD.md`.
+
+## YAML frontmatter (required)
+
+The `README.md` must open with a YAML block between `---` fences. HF parses this for license, search, and modality. Minimum fields:
+
+```yaml
+---
+pretty_name: "OpenH-RF — <contributor / dataset name>"
+license: cc-by-4.0
+task_categories:
+  - <hf-task>            # e.g. image-segmentation, image-classification
+tags:
+  - ultrasound
+  - rf                   # or iq, depending on data_type
+  - openh-rf
+  # optional modality override: 3d, audio, geospatial, image, tabular, text, timeseries, video
+  - 3d
+language:
+  - en
+size_categories:
+  - n<1K                 # or 1K<n<10K, 10K<n<100K, etc.
+---
+```
+
+Declaring `license: cc-by-4.0` in the frontmatter is what makes HF display the license badge on the dataset page — a separate `LICENSE` file is still good practice, but the frontmatter line is the load-bearing one for the HF UI.
+
+The markdown sections below all live in the **body** of the `README.md`, after the closing `---` of the frontmatter.
+
+---
+
+## Dataset Description
+One short paragraph: what the data is, what it captures (acquisition modality, anatomy, task focus), and the intended research contribution. Note whether it is clinical, phantom, simulated, or in vivo animal data.
+
+## Dataset Contributor(s)
+Contributing organization and primary point of contact.
+
+## Dataset Creation Date
+MM/DD/YYYY.
+
+## License / Terms of Use
+OpenH-RF requires **CC BY 4.0**. Confirm that the contributed data is cleared for this license (IP, patient consent, institutional review).
+
+## Intended Usage
+Briefly describe the application or task — e.g., sound speed estimation, advanced beamforming, segmentation, aberration correction.
+
+## Dataset Characterization
+- **Data Collection Method:** clinical / phantom / synthetic / animal
+- **Labeling Method:** N/A, human-annotated, synthetic ground truth, derived
+- **Acquisition system:** transducer geometry, element count, center frequency, sampling rate
+
+## Dataset Format
+All sub-datasets are submitted in the *zea* file format. Note any pre-processing applied before packaging — refocus/resample IP abstraction, demodulation, decimation, etc.
+
+## Dataset Quantification
+- Number of samples / frames / acquisitions
+- Train / validation / test split (if applicable)
+- Total size on disk
+- Per-sample feature table (name, shape, dtype, units, description)
+
+## Subject Metadata
+Aggregate statistics only — no PHI. Include where applicable: number of subjects, age range, sex distribution, anatomical region(s), pathology distribution, scanner/probe model.
+
+## Data Validation
+A `zea.Pipeline` that reconstructs a representative sample from the raw channel data (e.g., DAS → envelope → normalization → log compression to B-mode). Include the pipeline script and 1–2 example output images.
+
+## Known Issues
+Calibration quirks, missing fields, unit inconsistencies, artifacts, edge cases.
+
+## Ethical Considerations
+Consent status, de-identification approach, IRB or equivalent approval, any usage caveats.

--- a/.claude/skills/openh-rf-submission-eval/references/dimensions/01-format.md
+++ b/.claude/skills/openh-rf-submission-eval/references/dimensions/01-format.md
@@ -1,0 +1,56 @@
+# Dimension 1: Format compliance
+
+## Persona
+
+You are a **data-format auditor**. You read specs for a living and you find the diff between spec and reality fast. You are not opinionated about whether the format is good — only about whether *this file* matches *this spec*. You do not look at the data card or the science; that is someone else's job. Your output is dry and exact: field name, observed value, expected value, severity.
+
+## What you're checking
+
+The submission is actually in the *zea* file format and the on-disk structure matches the spec.
+
+## Artifacts you need
+
+- The `.zea` / `.hdf5` file(s) in the submission
+- `scripts/validate_zea_spec.py` — **the authoritative, programmatic compliance check**
+- `references/zea-format-notes.md` — human-readable companion (may lag the installed spec; the script is ground truth)
+
+**Do not read:** the data card, pipeline script, or any prose. This dimension is purely about the file on disk.
+
+## Checks
+
+0. **Run `scripts/validate_zea_spec.py <file>` first — this is the authoritative check.** It reconstructs zea's own `FileSpec` from the file (`FileSpec.from_hdf5`), which runs every dtype / shape / dimension-consistency validation the spec defines, *against the zea version installed in the eval environment* (recorded as `zea_version` in the output). Read the JSON:
+   - `compliant: true` → the file satisfies the installed zea spec. Proceed to the checks below only for items the spec does not cover (units conventions, NaN/Inf spot-checks, file-size sanity, naming).
+   - `compliant: false` → each string in `errors` is a precise violation; map it to a finding. A `FileSpec` exception is a `major` or `blocker` (blocker if a required group/field is absent or a shape is incompatible).
+   - Heed any zea **warnings** the script echoes (e.g., "Custom spatial map key(s) added" — a non-standard map key validated as a generic `Map`): record as `minor`/`info` and suggest the supported key.
+1. **File opens with `zea`.** (Subsumed by check 0; if `validate_zea_spec.py` cannot even open the file, that's a `blocker`.)
+2. **Required top-level groups exist.** A zea file has at minimum `data` (channel data) and `scan` (geometry + transmit definition); `probe` may be a separate group or derived from `scan` (`f.probe()`), depending on zea version — the validator settles this. Missing `data`/`scan` is a `blocker`.
+3. **Raw channel data is present.** `/data/raw_data` **must** exist and be non-empty. OpenH-RF requires every submission to include raw pre-beamformed channel capture data — non-negotiable, even if the proposal claimed an alternative. `validate_zea_spec.py` enforces this explicitly (`has_raw_data`) because zea's generic `FileSpec` does **not** require it. Missing/empty → `blocker`.
+4. **Channel-data array shape.** `/data/raw_data` must be `(n_frames, n_tx, n_ax, n_el, n_ch)` per the spec (`n_ax` = axial samples, `n_el` = elements, `n_ch` = channels, typically 1 for RF or 2 for I/Q). A documented variant is acceptable only if the dimension order is recorded in the file or data card.
+4. **Dtype is sensible.** Typically `float32` or `int16`. Object dtypes or strings in the data array are a `major`.
+5. **Units are recorded.** Sampling rate in Hz, center frequency in Hz, element positions in meters, sound speed in m/s. If units are missing or implicit, that's a `major`.
+6. **No NaN/Inf in the data array.** Spot-check a few frames. NaN/Inf is `major`.
+7. **File size is consistent.** Reported sample count × bytes-per-sample roughly matches file size on disk.
+
+## Severity rubric
+
+- `blocker`: file won't open, required groups missing, **`/data/raw_data` missing or empty**, channel data is all-zero
+- `major`: undocumented dimension order, missing units, NaN/Inf, dtype mismatches the spec
+- `minor`: optional fields missing (timestamps, frame indices), inconsistent but recoverable naming
+- `info`: minor naming preferences
+
+## Output
+
+Return a result block:
+
+```
+dimension: format_compliance
+status: pass | pass_with_notes | fail | blocked
+severity: info | minor | major | blocker
+findings:
+  - "<specific finding 1>"
+  - "<specific finding 2>"
+evidence:
+  - "<file path:field>: <observed value>"
+suggested_fixes:
+  - "<what the contributor should change>"
+```

--- a/.claude/skills/openh-rf-submission-eval/references/dimensions/02-reconstruction.md
+++ b/.claude/skills/openh-rf-submission-eval/references/dimensions/02-reconstruction.md
@@ -1,0 +1,76 @@
+# Dimension 2: Reconstruction & image quality
+
+## Persona
+
+You are an **ultrasound imaging engineer**. You have reconstructed thousands of B-mode images and you know what a good one looks like in the corner of your eye. You can tell the difference between a clinical artifact (acoustic shadowing behind a calcification — fine, that's physics) and a pipeline artifact (sign-flipped intensities — that's a bug). You don't grade for clinical quality; you grade for whether the reconstruction *makes sense given the data*.
+
+You're patient with quirky data and impatient with broken pipelines. When a pipeline crashes you read the traceback, you don't just give up. When the output looks weird you say *what's* weird about it — not "doesn't look right".
+
+## What you're checking
+
+The contributor's pipeline script actually runs on the contributor's data and produces a sensible B-mode image. "Sensible" means free of *pipeline-induced* artifacts; acquisition-induced artifacts (shadowing, reverb behind real reflectors, attenuation) are not your problem.
+
+## Artifacts you need
+
+- The zea `.hdf5` file(s)
+- The contributor's `reconstruct.py` (runnable reconstruction script) and `pipeline.yaml` (a saved `zea.Pipeline`, **one per track** in the file)
+- The contributor's reference B-mode image(s) / `.png` output, if provided
+- `scripts/judge_bmode.py` — objective sanity checks
+- `references/imaging-artifacts.md` — taxonomy of what to look for and how to distinguish acquisition vs pipeline issues
+
+Order this check after dimensions 1 and 3. If the file is malformed (dim 1 blocker) or metadata is incomplete (dim 3 blocker), this will fail for downstream reasons and the diagnostic will be unhelpful.
+
+## Checks
+
+1. **`reconstruct.py` and `pipeline.yaml` exist.** The submission must include a runnable `reconstruct.py` plus a saved `pipeline.yaml` — **one `pipeline.yaml` per track** in the file(s). If either is missing entirely, this dimension is `blocked` — flag for the orchestrator to auto-generate from `scripts/pipeline_template.py`. A multi-track file that is missing one or more of its per-track `pipeline.yaml` files is a `major` finding.
+2. **Pipeline runs without modification.** Execute as the contributor specified. No silent edits to make it work. Crashes → `blocker`, capture the traceback as evidence.
+3. **Pipeline produces a B-mode image.** Output is a 2D array, finite values, dynamic range consistent with log-compressed B-mode (typically -60 to 0 dB or normalized [0, 1]).
+4. **Run `scripts/judge_bmode.py` for objective sanity gates** — a cheap, deterministic pre-check that the pipeline produced a real image, not noise/constant/NaNs: 2D, finite, has spatial variance, dynamic range plausible for a log-compressed B-mode. If any gate fails, the reconstruction is broken regardless of how it looks — record and stop. These gates do **not** assess quality or similarity.
+5. **Perceptual inspection — view the rendered image directly (multimodal vision).** Render the reconstruction to PNG (`autofix/reference_bmode.png`) and *look at it* using your visual perception; do not rely on a scalar metric. Assess against the artifact taxonomy (`references/imaging-artifacts.md`):
+   - *Pipeline-induced artifacts* (any of these → `major` or `blocker`): sign-flipped intensities, wraparound, dominant ringing, all-noise output, geometric distortion not consistent with the scan geometry, severe banding from beamforming bugs, NaN holes
+   - *Resolution problems*: image looks blurrier than reasonable given the probe (low effective aperture? wrong sound speed?)
+   - *Spectral artifacts*: aliasing patterns, decimation artifacts, demodulation phase errors
+   - *Acquisition-induced artifacts* (these are *fine* — note as `info` if interesting): real acoustic shadowing, real reverberation behind a strong reflector, real attenuation
+   State *what* you see and *where* (e.g., "ring-down banding across the top third"), not just "looks fine".
+6. **Match to reference (perceptual, not SSIM).** If the contributor provided a reference B-mode, view both images side by side and judge whether they depict the **same structures / anatomy / geometry** — accounting for differences in grid resolution, field of view, dynamic range, and colormap, which are expected and not defects. SSIM and other pixel-registered metrics are unreliable here because reconstruction and reference rarely share a physical grid; do not use them as a gate. Flag only a *clear* structural disagreement (different scene, mirrored/rotated geometry, features present in one and absent in the other) as `major` — it usually means the metadata in the file disagrees with what the contributor actually used. When the difference is plausibly just scale/colormap/FOV, it is not a finding.
+
+## Standard reconstruction chain
+
+The contributor's script may differ, but conventionally a zea B-mode pipeline is:
+
+```
+DAS beamforming → envelope detection (Hilbert) → log compression → normalization
+```
+
+More exotic pipelines (MV beamforming, plane-wave compounding, REFoCUS) are fine — but should still terminate in a 2D log-compressed image.
+
+## Severity rubric
+
+- `blocker`: pipeline crashes, output is not an image, output is all-NaN/zero, NaN holes mid-image, sign-flipped intensities
+- `major`: pipeline-induced artifacts (dominant ringing, wraparound, severe banding), or a clear structural disagreement with the contributor's reference image (different scene/geometry, not merely scale/colormap/FOV)
+- `minor`: image quality issues that don't break interpretability (visible artifacts in corners, slight resolution loss)
+- `info`: acquisition-induced artifacts that are real features of the data; pipeline could be more efficient
+
+## Output
+
+Save the rendered B-mode image as `autofix/reference_bmode.png` so it can be embedded in the final report.
+
+```
+dimension: reconstruction
+status: pass | pass_with_notes | fail | blocked
+severity: ...
+findings:
+  - "Pipeline ran in <N>s; output shape <H, W>, dtype <...>"
+  - "Sanity gates (judge_bmode.py): <pass/fail summary>"
+  - "Perceptual inspection (vision): <what you saw — structures, any pipeline-induced artifacts and their location, or 'sensible B-mode, no pipeline artifacts'>"
+  - "Reference match (vision): <same structures / clear disagreement / no reference provided>"
+evidence:
+  - "rendered image saved to autofix/reference_bmode.png"
+  - "judge_bmode.py gate results: <summary>"
+suggested_fixes:
+  - "<concrete change to pipeline or metadata>"
+```
+
+## A note on judgment
+
+The hardest call is *acquisition-induced vs pipeline-induced*. A reverberation pattern behind a strong reflector might be the real physics (the contributor's lab phantom has a glass interface) — or might be a beamforming aliasing bug. When uncertain, say so explicitly in findings and recommend the contributor confirm. Don't flag uncertain calls as `major` — flag them as `minor` with a question for the contributor.

--- a/.claude/skills/openh-rf-submission-eval/references/dimensions/03-metadata.md
+++ b/.claude/skills/openh-rf-submission-eval/references/dimensions/03-metadata.md
@@ -1,0 +1,79 @@
+# Dimension 3: Metadata sufficiency
+
+## Persona
+
+You are a **reproducibility reviewer**. You have been burned, repeatedly, by datasets that "had everything" until you actually tried to use them. You ask: *can a stranger reconstruct from this, with no contact with the contributor?* You treat "I think this is implicit" as missing. You treat "it's in the code somewhere" as missing. You treat "the contributor mentioned this on a call" as missing. You are not pedantic, but you are exact.
+
+## What you're checking
+
+Every hyperparameter a downstream user would need to reconstruct an image from raw channel data is present in the zea file or data card. A novice should be able to do this without contacting the contributor.
+
+## Artifacts you need
+
+- The `.zea` file(s) (inspect groups/attributes)
+- The data card (for any metadata documented externally)
+- `references/zea-format-notes.md` for the canonical metadata list
+
+**This is the dimension most likely to surface "I think I have everything" submissions that secretly don't.** Be thorough.
+
+## Required metadata, by category
+
+Field names below are the zea spec fields (see `references/zea-format-notes.md`);
+`probe.*` and `metadata.*` fields are optional in the generic spec but become
+*required for reconstruction* in practice.
+
+### Transducer / probe (`/probe`)
+- [ ] `probe_geometry` `(n_el, 3)` in metres — element positions (number of
+      elements and pitch derive from this; there is no `n_elements`/`pitch` field)
+- [ ] `type` (linear, curved, phased, matrix)
+- [ ] `element_width`, `element_height` (m) — needed for aperture/elevation modelling
+- [ ] `probe_center_frequency` (Hz); `probe_bandwidth_percent` (%) — recommended
+
+### Acquisition system (`/scan`)
+- [ ] `sampling_frequency` (Hz)
+- [ ] `raw_data` dtype / quantization (float32 or int16) and `n_ch`
+- [ ] `tgc_gain_curve` `(n_ax)` — recommended, especially for clinical data
+- [ ] Demodulation state: raw RF (`n_ch`=1) vs IQ (`n_ch`=2); if IQ, `demodulation_frequency`
+
+### Transmit sequence (`/scan`)
+- [ ] `t0_delays` `(n_tx, n_el)`, `tx_apodizations` `(n_tx, n_el)` — per-element delay + weighting
+- [ ] `focus_distances` `(n_tx)`, `polar_angles` `(n_tx)`, `transmit_origins` `(n_tx, 3)` — define transmit type (focused/plane-wave/diverging/SA)
+- [ ] `initial_times` `(n_tx)` — A/D start time per transmit
+- [ ] `waveforms_one_way`/`waveforms_two_way` or a pulse description — recommended
+
+### Scan geometry
+- [ ] `sound_speed` (m/s) — required for beamforming
+- [ ] Imaging depth / time-of-flight range (from `n_ax`, `sampling_frequency`, `sound_speed`)
+- [ ] Coordinate convention: x = lateral, y = elevation, z = axial (depth)
+
+### Frame timing
+- [ ] `time_to_next_transmit` `(n_frames, n_tx)` or `(n_timing_intervals)` — inter-transmit/frame timing
+- [ ] For tracked/gated data: `metadata.probe_pose` / `metadata.ecg` timing (`start_time_offset`, `timestamps`)
+
+## Checks
+
+1. For each item above, locate it in the zea file (preferred) or the data card.
+2. Cross-check: values reported in the data card must match values in the zea file. Mismatch is `major`.
+3. Sanity-check ranges. Center frequency 1–20 MHz for medical ultrasound. Sound speed 1450–1600 m/s for soft tissue. Sampling rate ≥ 4× center frequency for RF (Nyquist with headroom). Out-of-range values are `major` unless justified in the data card.
+4. Required-vs-recommended distinction: missing a required field is `major` or `blocker` (blocker if it makes reconstruction impossible). Missing recommended is `minor`.
+
+## Severity rubric
+
+- `blocker`: missing transmit sequence, sampling rate, probe geometry, or sound speed — reconstruction is impossible
+- `major`: any required field missing, or mismatch between file and data card
+- `minor`: recommended fields missing
+- `info`: more metadata could be helpful but isn't necessary
+
+## Output
+
+```
+dimension: metadata_sufficiency
+status: ...
+severity: ...
+findings:
+  - "field <name>: <status>. <where it was/wasn't found>"
+evidence:
+  - "<file>:<group>/<attr>: <value> <units>"
+suggested_fixes:
+  - "Add <field> to <location>; expected dtype <...>, expected units <...>"
+```

--- a/.claude/skills/openh-rf-submission-eval/references/dimensions/04-data-card.md
+++ b/.claude/skills/openh-rf-submission-eval/references/dimensions/04-data-card.md
@@ -1,0 +1,92 @@
+# Dimension 4: Data card
+
+## Persona
+
+You are a **dataset documentation reviewer** — think Hugging Face data card reviewer with a HIPAA hat on. You read every section, you check for placeholder text (the giveaway is text that reads like instructions, not content), and you scan aggressively for PHI in places it shouldn't be. You appreciate good documentation and you call out vagueness. You do not nitpick formatting unless it actively obstructs comprehension.
+
+## What you're checking
+
+`README.md` exists at the dataset root, carries valid HF YAML frontmatter, is complete per the OpenH-RF data-card template, contains no placeholder text, and contains no PHI.
+
+The data card **is** the `README.md`. Hugging Face renders `README.md` as the dataset landing page (<https://huggingface.co/docs/hub/datasets-cards>), so there is exactly one user-facing document. A submission shipping a separate `DATA_CARD.md` alongside `README.md` is a `minor` finding (duplication, should be merged); a submission shipping *only* `DATA_CARD.md` and no `README.md` should still be evaluated against this dimension, but flagged with the rename as a `minor` suggested fix.
+
+## Artifacts you need
+
+- `README.md` at the dataset root (or a `DATA_CARD.md` fallback, flagged for rename)
+- `references/data-card-template.md` for the canonical section list and YAML frontmatter spec
+- `references/phi-checklist.md` for the PHI scan
+- The **added-beyond-proposal list** from the orchestrator's Step 1b alignment check (anything in the submission the proposal didn't promise), so you can verify each addition is documented here
+
+## Required YAML frontmatter
+
+The `README.md` must open with a YAML block (between `---` fences) containing at minimum:
+
+- `license: cc-by-4.0` (HF will render the license badge from this)
+- `pretty_name:` human-readable dataset name
+- `task_categories:` list mapped to HF taxonomy (e.g., `image-segmentation`, `image-classification`)
+- `tags:` list including modality tag (`ultrasound`, `rf`) and any HF modality override (e.g., `3d` for volumetric)
+
+Missing frontmatter entirely is `major`. Missing `license` is `blocker` (covered in dimension 6). Missing `pretty_name` or `task_categories` is `minor`.
+
+## Required sections
+
+The OpenH-RF data card template specifies these sections in the markdown body (after the YAML frontmatter), all required:
+
+- Dataset Description
+- Dataset Contributors
+- Dataset Creation Date (MM/DD/YYYY)
+- License / Terms of Use
+- Intended Usage
+- Dataset Characterization (Data Collection Method, Labeling Method, Acquisition system)
+- Dataset Format
+- Dataset Quantification (number of samples, splits, total size, per-sample feature table)
+- Subject Metadata (aggregate only — no PHI)
+- Data Validation (a `zea.Pipeline` reconstruction + 1–2 example outputs)
+- Known Issues
+- Ethical Considerations
+
+## Checks
+
+0. **`README.md` exists at dataset root.** Missing entirely is `major`. A bare `DATA_CARD.md` with no `README.md` is `major` with a `minor` rename suggestion; both files present is `minor` (merge into `README.md`).
+0b. **YAML frontmatter is valid and present.** Parseable, includes `license`, `pretty_name`, `task_categories`, `tags`. See severity rules above.
+1. **All sections present** (in the markdown body, after the frontmatter). Missing any is `major` (or `blocker` if it's License or Ethical Considerations).
+2. **No placeholder text.** Watch for "TODO", "TBD", "Lorem ipsum", "[insert ...]", "to be filled in", empty sections with just a header, or text that's clearly copy-pasted from the template without modification.
+3. **No PHI in Subject Metadata.** This section must be aggregate statistics only. If you see anything that looks like a name, MRN, date of birth (vs. age range), exact address, or a specific identifying detail tied to one subject, that's a `blocker` — flag for steering-group review and notify the contributor immediately.
+4. **Per-sample feature table is present and correctly formatted.** Columns: name, shape, dtype, units, description. If absent, that's `major`. (This is one of the auto-fixable items — note it for the orchestrator if the zea file has the info.)
+5. **Dates parseable.** Creation date should be a real date in MM/DD/YYYY.
+6. **License is CC BY 4.0.** Anything else is a `blocker` (covered more in dimension 6).
+7. **Intended Usage names a task.** Should map to one or more of the RFP task groups (6.1–6.6). Vague text like "general ultrasound research" is `minor`.
+8. **Everything in the submission is documented — including additions beyond the proposal.** Cross-check the README against the actual inventory and the added-beyond-proposal list. Any data type, modality, task, subject group, or derived product that is present but not described in the data card is a `major` finding. For each item that also goes beyond what the proposal promised, the feedback must tell the contributor to document the addition explicitly — what it is, how it was produced, and how to use it. Additions are welcome, but the submission must stay aligned with the proposal: anything extra has to be written down here.
+
+## Severity rubric
+
+- `blocker`: License or Ethical Considerations missing; any PHI detected
+- `major`: any required section missing, placeholder text in a substantive section, per-sample feature table missing, **content present but undocumented (including additions beyond the proposal)**
+- `minor`: vague intended-usage, missing recommended subsections (e.g., scanner model in Subject Metadata when applicable)
+- `info`: prose could be clearer, formatting inconsistencies
+
+## Output
+
+```
+dimension: data_card
+status: ...
+severity: ...
+findings:
+  - "Section '<name>': <complete | missing | placeholder | PHI-detected>"
+  - ...
+evidence:
+  - "<section>: <quote of the offending text or absence>"
+suggested_fixes:
+  - "Fill in section '<name>' with: <what's expected>"
+```
+
+## PHI red flags (be vigilant)
+
+Run a quick scan for these patterns in the data card and in any zea file attributes:
+- Date strings that look like full DOBs (e.g., "1962-04-23" rather than an age range)
+- All-caps strings that could be names ("PATIENT: J SMITH")
+- Strings matching MRN/medical record number formats
+- ZIP+4 codes, full street addresses
+- Filenames that include subject identifiers (e.g., "patient_jsmith_01.zea")
+
+Any hit on these is a `blocker`. Report the exact location and stop dimension processing for that field.

--- a/.claude/skills/openh-rf-submission-eval/references/dimensions/05-documentation.md
+++ b/.claude/skills/openh-rf-submission-eval/references/dimensions/05-documentation.md
@@ -1,0 +1,69 @@
+# Dimension 5: Documentation & clarity
+
+## Persona
+
+You are a **first-time user simulator**. Specifically: a second-year medical-imaging PhD student who has never spoken to the contributor, has 15 minutes, and needs to (1) understand what the data is, (2) reconstruct one B-mode frame, and (3) decide whether the data fits her project. You read the materials in the order a new user would: the HF dataset landing page (i.e., `README.md`) first, then the pipeline, then the images. Every time you would have to ask a question, that's friction. You report friction.
+
+The `README.md` is the only user-facing document — there is no separate data card. (See dimension 4 for the `README.md`'s structural requirements; this dimension evaluates whether what's there is *usable*, not whether the sections exist.)
+
+You are *not* harsh about prose quality. Bad writing is fine. Missing information is not.
+
+## What you're checking
+
+A graduate student in medical imaging who has never spoken to the contributor can, in roughly 15 minutes:
+
+1. Understand what the data is and what task it supports
+2. Run the pipeline and reconstruct a B-mode image
+3. Know what they can and cannot do with the data
+
+## Artifacts you need
+
+- `README.md` at the dataset root (the rendered HF dataset landing page)
+- Comments in the pipeline script and any supplementary docs
+- The reference B-mode image(s)
+
+## The novice-user simulation
+
+Walk through what a new user would actually do, in order:
+
+1. **Open the HF dataset page (i.e., `README.md`).** Can they identify the modality, anatomy, and task within the first paragraph? (Should be in "Dataset Description".)
+2. **Find the pipeline.** Is its location obvious from the `README.md`? Or do they have to grep?
+3. **Run the pipeline.** Are dependencies declared? Are there inline comments? Does the pipeline say what each stage does?
+4. **Interpret the output.** Can they tell what they're looking at? Are the reference images labeled (anatomy, view, frame number)?
+5. **Decide if it suits their use case.** Does the data card make the intended task and limitations explicit?
+
+For each step, ask: *would a novice user hit a wall here?* A wall is anything that would make them message the contributor for help.
+
+## Checks
+
+1. **Dataset Description leads with the essentials.** Modality, anatomy, acquisition type, and task — all in the first 2–3 sentences. Burying these is `minor`.
+2. **Pipeline script has at least minimal comments.** Each major stage (beamforming, envelope detection, log compression) should have a one-line comment. Bare code with no narrative is `minor`.
+3. **Reference B-mode images are labeled.** Should say what anatomy, what frame, what view. Unlabeled images are `minor`.
+4. **Dependencies are listed.** Either a `requirements.txt`, a `pyproject.toml`, or explicit imports at the top of the pipeline. Missing is `minor`.
+5. **Known Issues section is honest.** "None" is a `minor` red flag — every real dataset has at least minor calibration quirks. If they say "none", spot-check: do you see any in the data?
+6. **No undefined acronyms.** Common ones (DAS, RF, IQ, B-mode, PRF) are fine. Acronyms specific to the contributor's institution or pipeline must be expanded on first use.
+7. **Numbers have units.** Wherever the data card cites a quantity (frequency, depth, frame count), units must be present.
+
+## Severity rubric
+
+This dimension should rarely produce `blocker` or `major`. The goal is to surface friction, not block submissions.
+
+- `major`: reserved for cases where documentation actively misleads — e.g., the data card says one thing and the file shows another
+- `minor`: documentation gaps that would force a novice to ask the contributor questions
+- `info`: prose improvements, formatting suggestions
+
+## Output
+
+```
+dimension: documentation_clarity
+status: ...
+severity: ...
+findings:
+  - "Step <N> of novice simulation: <what worked / what didn't>"
+evidence:
+  - "<quote from data card or pipeline>"
+suggested_fixes:
+  - "Add <thing> to <location>"
+```
+
+Be specific in suggested fixes. "Improve clarity" is not actionable. "Add one sentence to Dataset Description naming the anatomical view (e.g., 'parasternal long-axis')" is.

--- a/.claude/skills/openh-rf-submission-eval/references/dimensions/06-licensing.md
+++ b/.claude/skills/openh-rf-submission-eval/references/dimensions/06-licensing.md
@@ -1,0 +1,51 @@
+# Dimension 6: Licensing & IP
+
+## Persona
+
+You are an **open-source licensing reviewer**. You have seen well-intentioned releases get pulled because of one bad clause. You read every word of the license declaration. You scan for restrictions that contradict CC BY 4.0 ("non-commercial", "research-only", "not for redistribution"). You check that consent actually covers public release, not just "research use" — there is a difference and it matters. You are unsympathetic to vague language. CC BY 4.0 or nothing; that's the bar.
+
+## What you're checking
+
+The submission is cleared for CC BY 4.0 release with no third-party IP encumbrances. This is the dimension that protects the open release.
+
+## Artifacts you need
+
+- A **`LICENCE`/`LICENSE` file (either spelling, any extension) at the submission root** — required. The submission guide uses the spelling `LICENCE`.
+- The data card (License / Terms of Use section)
+- The proposal acceptance record, if available, where the contributor committed to CC BY 4.0
+
+## Checks
+
+1. **LICENCE file present at submission root.** A `LICENCE`/`LICENSE` file (either spelling, extension optional) must exist at the top level of the submission and contain the verbatim CC BY 4.0 legal code (or an unambiguous SPDX header `SPDX-License-Identifier: CC-BY-4.0` plus a link to the canonical text). A statement of intent in the proposal alone is **not** sufficient — without an in-tree LICENSE the dataset travels without its license and downstream consumers cannot rely on it. Missing LICENSE file is `major` (contributor-fixable; not a blocker because intent has been declared, but cannot accept until the file is in place).
+2. **Explicit CC BY 4.0 declaration.** The data card must say, plainly, that the dataset is released under CC BY 4.0. Vague phrasing ("open license", "permissive") is `major`. Anything other than CC BY 4.0 (e.g., CC BY-NC, CC BY-SA, custom license) is a `blocker` — the RFP requires CC BY 4.0 for compatibility with the aggregate release.
+3. **No "research-only" or "non-commercial" restrictions.** CC BY 4.0 explicitly permits commercial use. Any restriction language that contradicts this is a `blocker`.
+4. **No bundled third-party data with incompatible licenses.** Scan for: borrowed phantoms or simulation outputs from another dataset, third-party annotations, or any "courtesy of X" attributions that don't include licensing info. If found, `major` — needs clarification.
+5. **Contributor attribution clear.** CC BY 4.0 requires attribution. The data card must name the contributing organization and primary point of contact. Missing is `major`.
+6. **Patient consent compatible with public release.** Consent must explicitly cover open-access research data sharing. Consent that only covers "internal research" or "clinical use" is a `blocker` — flag for legal review.
+7. **For animal data:** confirm IACUC approval (or local equivalent) covers data sharing.
+8. **For simulation/phantom data:** confirm the simulation software (e.g., k-Wave, FOCUS, custom) license permits redistribution of outputs. Most do; flag any that don't.
+
+## Severity rubric
+
+- `blocker`: any license other than CC BY 4.0; any restriction inconsistent with CC BY 4.0; consent that doesn't cover open release
+- `major`: **missing LICENSE file at submission root** (even if proposal declares CC BY 4.0); vague license language; missing attribution; bundled third-party data of unclear provenance
+- `minor`: LICENSE file present and correct but documentation around it is sparse (e.g., missing suggested citation, no SPDX header in data card)
+- `info`: nice-to-have additions (e.g., suggested citation format)
+
+## Output
+
+```
+dimension: licensing
+status: ...
+severity: ...
+findings:
+  - "License declaration: <verbatim quote>"
+  - "Third-party content detected: <yes/no>; <details>"
+evidence:
+  - "<file>: <quote>"
+suggested_fixes: [...]
+```
+
+## Special note
+
+Licensing problems are usually the hardest to fix after the fact — they often require going back to the institutional ethics board or legal team. If you find a `blocker` here, the report's action items should make clear that this is the highest-priority fix, even above technical blockers.

--- a/.claude/skills/openh-rf-submission-eval/references/dimensions/07-ethics.md
+++ b/.claude/skills/openh-rf-submission-eval/references/dimensions/07-ethics.md
@@ -1,0 +1,86 @@
+# Dimension 7: Ethics & compliance
+
+## Persona
+
+You are a **research compliance officer**. Your disposition is *thorough and skeptical, but not obstructionist*. You assume contributors have good intent but that mistakes happen — the kind of mistake that ends up in a press release. You read every string field in a zea file looking for what shouldn't be there. When you find something, you note its location and category without quoting the offending content (the report itself becomes a document, and you don't propagate identifiers).
+
+You care about getting the right answer, not about racking up findings.
+
+## What you're checking
+
+The submission meets the ethics and compliance requirements appropriate to its data tier (in-vivo human, in-vivo animal, ex-vivo, phantom, simulation), and contains no Protected Health Information.
+
+## Artifacts you need
+
+- The data card (Ethical Considerations + Subject Metadata sections)
+- Any IRB/IACUC/ethics documentation provided
+- The zea file attributes and any string fields (for residual identifiers)
+- `references/phi-checklist.md` — the canonical HHS Safe Harbor 18 identifiers
+
+## Tier-specific requirements
+
+### In-vivo human (clinical or research platform)
+- IRB approval number cited, or equivalent ethics-board approval named
+- HIPAA Safe Harbor de-identification confirmed (or equivalent local standard, e.g., GDPR Article 26 pseudonymization for EU data)
+- Consent status documented — explicit consent for data sharing, not just for the procedure
+- No HHS Safe Harbor 18 identifiers present (run the checklist at `references/phi-checklist.md`)
+- If pediatric data (under 18): parental consent documented
+
+### In-vivo animal
+- IACUC approval (or equivalent) cited
+- Adherence to ARRIVE 2.0 reporting standards
+- Species, strain, source documented in aggregate
+- Welfare/anesthesia approach noted
+
+### Ex-vivo animal tissue
+- Source documented (commercial supplier or research animal program)
+- If from a research animal program, IACUC approval cited
+- Tissue handling protocol noted
+
+### Phantom / table-top
+- Phantom source documented
+- No ethics requirements beyond standard lab practice — checks should be minimal
+
+### Simulation
+- Simulation framework and version named (k-Wave, FOCUS, custom)
+- No ethics requirements — verify only that no human/animal data is mixed in
+
+## Checks
+
+1. **Identify the tier** from the data card's "Dataset Characterization → Data Collection Method".
+2. **Apply the tier-specific checklist.** Missing required items at the appropriate tier is severe.
+3. **PHI scan (for human data).** Run the full HHS Safe Harbor 18-identifier scan from `references/phi-checklist.md`. Scan everywhere strings appear: data card prose, file/group/attribute names in the zea file, any string-valued fields inside the zea file, and embedded metadata. Anything matching any of the 18 categories is a `blocker`.
+4. **Cross-check Subject Metadata.** Must be aggregate. Min/max/median statistics are fine; per-subject rows are not.
+5. **Honesty check.** "No ethical considerations" for human-subject data is a red flag — there are always considerations. Flag as `major`.
+
+## Severity rubric
+
+- `blocker`: any of the HHS Safe Harbor 18 identifiers found anywhere; consent missing or inadequate; no IRB for human data when required
+- `major`: ethics documentation present but incomplete; tier-required field missing
+- `minor`: aggregate stats could be more thorough; protocol details thin
+- `info`: nice-to-have documentation additions
+
+## Output
+
+```
+dimension: ethics_compliance
+status: ...
+severity: ...
+findings:
+  - "Tier: <in-vivo human / animal / ex-vivo / phantom / simulation>"
+  - "<tier-specific check>: <pass/fail/details>"
+  - "PHI scan: <N> categories triggered (see locations)"
+evidence:
+  - "<file>:<path>: <PHI category name>, NOT the value"
+suggested_fixes: [...]
+```
+
+## Critical handling rule for PHI
+
+If you find any of the HHS Safe Harbor 18:
+
+- **Do not include the offending string verbatim** in the report. Note its location and the identifier category instead.
+  - Bad: "Found MRN 12345678 in `data/scan/subject_id`"
+  - Good: "Identifier category 'Medical record number' triggered at `data/scan/subject_id`"
+- Mark this as a `blocker` and flag it as the top priority action item.
+- Recommend the contributor re-export with the offending field stripped or hashed (where a re-identification code is permissible — see `references/phi-checklist.md` on re-identification codes).

--- a/.claude/skills/openh-rf-submission-eval/references/imaging-artifacts.md
+++ b/.claude/skills/openh-rf-submission-eval/references/imaging-artifacts.md
@@ -1,0 +1,114 @@
+# Ultrasound image artifact taxonomy
+
+A reference for dimension 2 (reconstruction). The central question this file answers:
+
+> *Is this artifact in the image because of the physics of the acquisition (which is fine — it's the real data), or because the pipeline did something wrong (which is what we're here to catch)?*
+
+You can let acquisition-induced artifacts through. You cannot let pipeline-induced ones through.
+
+---
+
+## Part 1: Acquisition-induced artifacts (these are FINE)
+
+These come from the physics of how ultrasound waves interact with tissue. They're features of the real data and a downstream user needs them preserved. **Note them as `info` if interesting, never as findings against the submission.**
+
+### Acoustic shadowing
+A dark anechoic band *behind* a highly attenuating or reflective structure (bone, calcification, gas, stone). Looks like a vertical dark stripe extending down from the bright structure.
+- *How to tell it's real*: there's a clear bright reflector at the top of the shadow.
+- *Diagnostic value*: actually useful — shadows behind kidney stones, gallstones, calcifications.
+
+### Acoustic enhancement
+The opposite: a bright region *behind* a structure that attenuates less than surrounding tissue (e.g., a fluid-filled cyst).
+- *How to tell it's real*: there's a clear hypoechoic structure (fluid pocket) above the bright region.
+
+### Reverberation (real)
+Multiple parallel echoes from sound bouncing between two strong reflectors. Common at strong tissue/air or tissue/metal interfaces (lung pleura, mechanical valves, catheter wires).
+- *How to tell it's real*: the reverb spacing matches a physically plausible reflector-to-reflector distance, and the artifact *fades with depth* (each bounce loses energy).
+
+### Comet tail / ring-down
+A reverberation variant — a short, intense, parallel-line trailing pattern from a small strong reflector (gas bubbles, metal fragments).
+- *How to tell it's real*: associated with a known strong reflector.
+
+### Mirror image
+A duplicated image of a real structure on the other side of a highly reflective interface (commonly diaphragm in liver imaging).
+- *How to tell it's real*: located symmetrically across an obvious reflective surface.
+
+### Edge / refraction artifacts
+Bright lines or shadowing at sharp tissue boundaries due to refraction of the beam.
+- *How to tell it's real*: localized to anatomical edges.
+
+### Attenuation
+General loss of signal with depth. Image gets darker the deeper you go.
+- *How to tell it's real*: it's monotonic and roughly exponential.
+
+---
+
+## Part 2: Pipeline-induced artifacts (these are BUGS)
+
+These come from errors in how the reconstruction was performed. They should not be in a correctly-built B-mode image and indicate a fix is needed.
+
+### Sign-flipped / inverted intensities
+The image looks like a photographic negative. Bright tissue is dark, anechoic regions are bright.
+- *Cause*: log compression applied without taking the magnitude first, or a sign error in the envelope.
+- *Severity*: `blocker`. The image is wrong.
+
+### Wraparound / aliasing in azimuth
+Structures appear to "wrap" from one side of the image to the other.
+- *Cause*: angular aliasing in plane-wave compounding, or insufficient lateral spacing relative to wavelength.
+- *Severity*: `major` if dominant, `minor` if subtle.
+
+### Spectral / decimation aliasing
+Repeating banded pattern in the axial direction, often regular.
+- *Cause*: undersampled axial data, or IQ-demodulated data treated as RF (or vice versa).
+- *Severity*: `major`. Reconstruction parameters disagree with the data.
+
+### Dominant ringing
+The image has obvious oscillating bright/dark bands not associated with any anatomy.
+- *Cause*: usually a missing or wrong apodization, or a Gibbs-like effect from a hard truncation.
+- *Severity*: `major` if it dominates the image. `minor` if mild and at edges.
+
+### Geometric distortion inconsistent with scan geometry
+The image's spatial aspect ratio or curvature doesn't match what the probe + scan geometry imply (e.g., a linear-probe image showing curvilinear sector geometry).
+- *Cause*: wrong scan-geometry parameters used in beamforming.
+- *Severity*: `blocker`. The reconstruction is geometrically wrong; downstream users will derive wrong measurements.
+
+### Severe banding from beamforming bugs
+Discrete vertical or radial bands corresponding to individual transmit events that didn't blend properly.
+- *Cause*: missing or wrong per-transmit weighting in coherent compounding.
+- *Severity*: `major`.
+
+### NaN holes mid-image
+Patches of NaN or zero in the interior of the image (not at the edges where it's normal).
+- *Cause*: division by zero in normalization, log of zero, or a beamforming bug at certain depths.
+- *Severity*: `blocker`.
+
+### All-noise output
+The image has no spatial structure — just speckle-like noise everywhere.
+- *Cause*: beamforming delays are wrong (wrong sound speed, wrong element positions), so coherent summing doesn't actually align echoes.
+- *Severity*: `blocker`.
+
+### Low effective resolution
+Image is much blurrier than the probe's nominal resolution would predict.
+- *Cause*: typically a too-small effective aperture, missing apodization, or wrong sound speed.
+- *Severity*: `major` if dramatic, `minor` if subtle.
+
+### Demodulation phase error
+For IQ data: lateral position errors that look like the image is slightly sheared.
+- *Cause*: wrong demodulation frequency, or RF/IQ misidentification.
+- *Severity*: `major`.
+
+---
+
+## Part 3: The judgment call
+
+The tricky cases:
+
+- **Reverberation behind a strong reflector**: real (Part 1) or beamforming aliasing (Part 2)? Look at *spacing* — physical reverb has spacing equal to reflector-pair distance. Aliasing reverb has spacing that's a divisor of the array geometry.
+- **Banding**: anatomical (real fascial layers) or beamforming (per-transmit banding)? Banding aligned with the transmit pattern is the pipeline. Banding aligned with depth is anatomy.
+- **Resolution loss**: real low-frequency probe vs aperture/sound-speed bug? Compare to the probe's nameplate center frequency. If a 10 MHz probe is producing 3 MHz resolution, that's a bug.
+
+When you can't tell, **say so explicitly** in the finding and downgrade to `minor` with a question for the contributor — not `major` based on a guess.
+
+## Sources
+
+The taxonomy in Part 1 is grounded in standard radiology references on B-mode artifacts (acoustic shadowing/enhancement, reverberation, mirror image, comet tail/ring-down, refraction edge artifacts). The pipeline-induced taxonomy in Part 2 reflects common failure modes in signal-processing-based reconstruction; it's drawn from typical bugs in academic and open-source beamforming pipelines.

--- a/.claude/skills/openh-rf-submission-eval/references/phi-checklist.md
+++ b/.claude/skills/openh-rf-submission-eval/references/phi-checklist.md
@@ -1,0 +1,59 @@
+# PHI checklist: HHS Safe Harbor 18 identifiers
+
+This is the canonical list of 18 identifiers that must be removed from data for it to qualify as de-identified under the HIPAA Privacy Rule's Safe Harbor method (45 CFR § 164.514(b)(2)). The list and de-identification standard are issued by the U.S. Department of Health and Human Services (HHS) Office for Civil Rights.
+
+Reference (read if needed for edge cases):
+- HHS Guidance: https://www.hhs.gov/hipaa/for-professionals/special-topics/de-identification/index.html
+- 45 CFR § 164.514(b) — the regulatory text
+
+**Important framing.** Safe Harbor is a *rules-based checklist*, not a guarantee. A dataset that passes Safe Harbor can still be re-identifiable in small populations or when linked with external data. The HHS standard also requires that the covered entity have *no actual knowledge* that the remaining information could identify an individual. Treat that as a separate question after the 18-item scan.
+
+For OpenH-RF, public release means we apply Safe Harbor strictly. If a contributor wants to retain something Safe Harbor removes (e.g., month of service), that requires the Expert Determination pathway, which is out of scope for automated evaluation — flag for steering-group review.
+
+## The 18 identifiers
+
+Scan everywhere strings or numbers appear — data card prose, zea file attributes, file/group/dataset names, any string-valued data fields, and embedded file metadata.
+
+| # | Category | What to look for |
+|---|---|---|
+| 1 | **Names** | Full names, first/last, initials, nicknames, maiden names. Also names of relatives, employers, or household members of the subject. |
+| 2 | **Geographic subdivisions smaller than a state** | Street address, city, county, precinct, ZIP code. ZIP3 is allowed *only* if the combined population of the ZIP3 area is >20,000 and certain low-population ZIP3s are replaced with 000. Anything finer than ZIP3 is out. |
+| 3 | **Dates (except year) related to an individual** | Birth date, admission/discharge dates, date of death, appointment timestamps, exact times. *Year alone is OK.* For ages over 89, aggregate as "90 or older" — exact age 90+ is itself an identifier. |
+| 4 | **Telephone numbers** | Any phone number format. |
+| 5 | **Fax numbers** | Yes, still on the list. |
+| 6 | **Email addresses** | Any email, including institutional ones tied to an individual subject. |
+| 7 | **Social Security numbers** | Any portion, full or partial. |
+| 8 | **Medical record numbers (MRN)** | Hospital MRNs, EHR patient IDs. Watch for fields named `subject_id`, `patient_id`, `record_id` that contain MRN-format values. |
+| 9 | **Health plan beneficiary numbers** | Insurance member IDs. |
+| 10 | **Account numbers** | Billing/account numbers tied to the patient. |
+| 11 | **Certificate / license numbers** | Driver's license, professional licenses. |
+| 12 | **Vehicle identifiers and serial numbers** | License plates, VINs. |
+| 13 | **Device identifiers and serial numbers** | Implant serial numbers, pacemaker IDs, *and (relevant here) probe/scanner serial numbers if they can be linked back to an individual scan session.* See note below. |
+| 14 | **URLs** | Web addresses, especially patient-portal URLs or links containing tokens. |
+| 15 | **IP addresses** | IPv4/IPv6 in any embedded metadata. |
+| 16 | **Biometric identifiers** | Fingerprints, voice prints, retinal scans. *Includes voice recordings that could be voice-printed.* |
+| 17 | **Full-face photographs and comparable images** | Any image that could identify the subject by face. Relevant to OpenH-RF only if image-of-acquisition material is bundled — channel data itself is fine. |
+| 18 | **Any other unique identifying number, characteristic, or code** | The catch-all. Custom study codes, internal tokens, novel ID schemes. *When in doubt, treat conservatively.* |
+
+## Things that frequently appear in zea files and warrant attention
+
+- `subject_id`, `patient_id`, `study_id` — check the *values*, not just the names. If they're sequential integers (subject_001 … subject_042), that's fine. If they're MRN-format, that's identifier #8.
+- `acquisition_datetime` — must be truncated to year only (or removed) for human data, per identifier #3.
+- `operator_name`, `sonographer` — not subject identifiers, but identifier #1 still applies if a relative or household member of the subject. Generally these should be removed or replaced with role labels.
+- Device serial numbers — identifier #13 applies only if traceable to an individual scan session. Model name + general probe info is fine; specific serial numbers should be evaluated.
+- Filenames — strip identifiers from filenames too. `scan_jsmith_20240603.zea` triggers identifiers #1 and #3.
+
+## Re-identification codes
+
+A "re-identification code" (an internal token the contributor can use to link back to the original record) is **permitted** under Safe Harbor *only if*:
+1. The code is not derived from any of the 18 identifiers (no hashes of names, no encrypted SSNs)
+2. The mapping is kept by the contributor and not disclosed
+
+If a submission includes obviously-tokenized subject IDs (e.g., random UUIDs), that's fine — note that the contributor must not include the mapping table in the public release.
+
+## What to do when triggered
+
+Per the protocol in `dimensions/07-ethics.md`:
+1. Mark the finding as a `blocker`
+2. Record the location (file, group, attribute path) and the identifier category — *never the offending value itself*
+3. Recommend re-export with the offending field removed, tokenized, or generalized (e.g., dates → year only)

--- a/.claude/skills/openh-rf-submission-eval/references/rfp-summary.md
+++ b/.claude/skills/openh-rf-submission-eval/references/rfp-summary.md
@@ -1,0 +1,57 @@
+# OpenH-RF RFP summary
+
+Condensed reference for evaluators. Full RFP is the authoritative source — pull it up if a corner case arises.
+
+## What OpenH-RF is
+
+A collaborative dataset initiative (Stanford, TU Eindhoven, NVIDIA) targeting ≥20,000 pre-beamformed ultrasound channel-capture measurements with task labels, released CC BY 4.0 on Hugging Face. Goal: enable end-to-end foundation models for ultrasound.
+
+## Accepted task groups
+
+- **6.1 Generalized Reconstruction** — compressed sensing, super-resolution, reverb suppression, adaptive transmit, aberration correction, harmonic imaging
+- **6.2 Blood Flow** — color/power Doppler, slow flow, functional ultrasound, CEUS, ULM
+- **6.3 Quantitative** — attenuation, sound speed, backscatter coefficient
+- **6.4 Motion** — tissue Doppler, shear wave elastography, strain
+- **6.5 Interpretation** — segmentation, VQA, narration, radiological reports
+- **6.6 Other** — continuous monitoring, USCT, passive cavitation, molecular imaging, neuromodulation, histotripsy
+
+## Tier weighting
+
+For steering-group prioritization, not for pass/fail evaluation:
+
+| Tier | Weight |
+|---|---|
+| In-vivo human (clinical platform) | ×100 |
+| In-vivo human (research platform) | ×40 |
+| In-vivo animal | ×20 |
+| Ex-vivo animal tissue | ×4 |
+| Phantom / table-top | ×1 |
+| Simulation | ×1 |
+
+## Hard requirements
+
+- Channel-capture (pre-beamformed) data, not beamformed images
+- *zea* file format
+- CC BY 4.0 license
+- HIPAA Safe Harbor (or local equivalent) for human data
+- ARRIVE 2.0 for animal data
+- IRB approval where applicable
+- No third-party IP encumbrances
+
+## Encouraged but not required
+
+- Time-aligned narration/description
+- Anonymized correlated patient metadata (BMI, age, gender)
+- Operator expertise labels (expert/intermediate/novice)
+- Quality and success labels (excellent/good/poor; failure/recovery/success)
+- Time-aligned video of acquisition
+- 6DoF probe tracking
+
+## Timeline (for context only — submissions arriving outside these windows are still evaluated normally)
+
+- RFP released: Mar 16, 2026
+- Proposal deadline: Jun 10, 2026
+- Data collection window: May 1 – July 12, 2026
+- Cleanup/standardization: through Aug 1, 2026
+- Model training: Aug 1 – Sep 1, 2026
+- Public release: October 2026

--- a/.claude/skills/openh-rf-submission-eval/references/zea-format-notes.md
+++ b/.claude/skills/openh-rf-submission-eval/references/zea-format-notes.md
@@ -1,0 +1,152 @@
+# zea file format notes
+
+> **Authoritative check is programmatic.** For dimension 1, run
+> `scripts/validate_zea_spec.py <file>` — it reconstructs zea's own `FileSpec`
+> from the file and validates against the zea version installed in the eval
+> environment (the spec *as code*, which cannot drift from these prose notes).
+> The notes below are a human-readable companion for interpreting results and
+> spotting recommended-but-not-required fields; if they ever disagree with the
+> installed zea spec, **the installed spec wins**.
+
+The authoritative human-readable spec is the OpenH-RF docs channel, which always
+tracks the latest accepted revision of the data-acquisition format:
+
+- **<https://zea.readthedocs.io/en/openh-rf-latest/data-acquisition.html>** — the spec
+- <https://zea.readthedocs.io/en/openh-rf-latest/> — full zea docs (pipeline, ops, beamforming, config)
+- <https://github.com/tue-bmd/zea> — source
+
+The summary below mirrors that page so an evaluator can interpret findings without
+leaving the skill. SI units throughout (Hz, s, m, V, rad); field names are
+`snake_case`.
+
+## Top-level structure
+
+A zea file is HDF5-backed. **Single-track** files have `data/` + `scan/` at the
+root; **multi-track** files replace those with a `tracks/` group (each track has
+its own `data/` + `scan/`), with `probe/` and `metadata/` shared.
+
+```
+file.hdf5
+├── attrs: us_machine, description, zea_version, acquisition_time   (all optional)
+├── data/        # raw + derived data products          (single-track)
+├── scan/        # acquisition parameters                (single-track)
+├── probe/       # transducer geometry/specs             (shared)
+├── metadata/    # subject, annotations, signals, pose   (optional)
+├── metrics/     # quality metrics                       (optional)
+└── tracks/      # multi-track only: track_0/, track_1/ … each with data/ + scan/
+    track_schedule  # optional int32 (n_total_tx): maps each transmit to a track
+```
+
+## `/data` — raw and derived products
+
+A single-track file must contain **`raw_data` or at least one derived product**;
+OpenH-RF additionally **requires `raw_data`** (enforced by `validate_zea_spec.py`,
+since zea's generic spec does not).
+
+| Field | Dtype | Shape | Units | Notes |
+|---|---|---|---|---|
+| `raw_data` | float32 / int16 | `(n_frames, n_tx, n_ax, n_el, n_ch)` | V | Raw channel data |
+
+Derived products are each a **sub-group** with a `values` array plus optional
+`coordinates` and metadata (`labels`, `description`, `unit`, `min`, `max`):
+
+- `aligned_data` — ToF-corrected: `(n_frames, n_tx, n_ax, n_el, n_ch)`
+- `beamformed_data` — beamsummed: `(n_frames, z, x, [y], n_ch)`
+- `envelope_data` — `(n_frames, z, x, [y])`
+- `image` — log-compressed B-mode: `(n_frames, z, x, [y])`, float32/uint8
+- `segmentation` — `(n_frames, z, x, [y], n_labels)`, **bool**, with `labels` (class names)
+- `sos_map`, `strain_percentage_map`, `shear_wave_elastography_map`,
+  `tissue_doppler`, `color_doppler` — spatial maps (m/s, %, etc.)
+- `<custom>` — arbitrary key, validated as a generic `Map` (`values` + optional
+  `coordinates`). zea emits a warning for non-standard keys; record as `minor`.
+
+**Coordinates are point-based.** Spatial products carry an optional `coordinates`
+array of shape `(*spatial, 3)` giving the per-pixel Cartesian position in metres,
+ordered `(x, y, z)` — e.g. 2D `(n_frames, z, x, 3)`, 3D `(n_frames, z, x, y, 3)`.
+This replaces the older extent-based representation.
+
+## `/scan` — acquisition parameters
+
+Required unless marked optional.
+
+| Field | Dtype | Shape | Units | Req | Notes |
+|---|---|---|---|---|---|
+| `sampling_frequency` | float32 | scalar | Hz | yes | A/D rate |
+| `center_frequency` | float32 | scalar or `(n_tx)` | Hz | yes | Transmit pulse center freq |
+| `demodulation_frequency` | float32 | scalar or `(n_tx)` | Hz | yes | IQ demod freq |
+| `initial_times` | float32 | `(n_tx)` | s | yes | A/D start time per transmit |
+| `t0_delays` | float32 | `(n_tx, n_el)` | s | yes | Transmit delay per element |
+| `tx_apodizations` | float32 | `(n_tx, n_el)` | – | yes | Transmit weighting |
+| `focus_distances` | float32 | `(n_tx)` | m | yes | Focal distance per transmit |
+| `transmit_origins` | float32 | `(n_tx, 3)` | m | yes | Beam origin (x,y,z) |
+| `polar_angles` | float32 | `(n_tx)` | rad | yes | Beam polar angle |
+| `time_to_next_transmit` | float32 | `(n_frames, n_tx)` or `(n_timing_intervals)` | s | no | Inter-transmit time |
+| `azimuth_angles` | float32 | `(n_tx)` | rad | no | Beam azimuth |
+| `sound_speed` | float32 | scalar | m/s | no | Medium speed of sound |
+| `tgc_gain_curve` | float32 | `(n_ax)` | – | no | Time-gain compensation |
+| `waveforms_one_way` / `waveforms_two_way` | float32 | `(n_tx, n_samples_*)` | V | no | Transmit waveforms |
+
+Transmit *type* (focused / plane-wave / diverging / synthetic-aperture) is
+expressed through `t0_delays`, `focus_distances`, `polar_angles`, and
+`transmit_origins` rather than a single enum.
+
+## `/probe` — transducer (all fields optional)
+
+| Field | Dtype | Shape | Units | Notes |
+|---|---|---|---|---|
+| `name` | str | scalar | – | Probe model |
+| `type` | str | scalar | – | `linear`, `phased`, `curved`, `matrix`, … |
+| `probe_geometry` | float32 | `(n_el, 3)` | m | Element positions (x,y,z) — `n_el` and pitch derive from this |
+| `probe_center_frequency` | float32 | scalar | Hz | Nominal center freq |
+| `probe_bandwidth_percent` | float32 | scalar | % | Fractional bandwidth |
+| `element_width` | float32 | scalar | m | |
+| `element_height` | float32 | scalar | m | Elevation aperture |
+| `lens_sound_speed` | float32 | scalar | m/s | |
+| `lens_thickness` | float32 | scalar | m | |
+
+Note: there is **no** `geometry_type`, `n_elements`, `pitch`, or `radius` field —
+geometry is the explicit `probe_geometry` point cloud.
+
+## `/metadata` — subject, annotations, signals, pose (all optional)
+
+Root: `credit` (str), `text_report` (str). Sub-groups:
+
+- **`subject`**: `id` (str), `type` (str, e.g. "human"/"phantom"), `age` (uint8, yr),
+  `sex` (str), `fat_percentage` (float32). **De-identify** — see PHI checklist.
+- **`annotations`** (per-frame or scalar str): `anatomy`, `view`, `label`,
+  `image_quality`.
+- **`probe_pose`** — transducer tracking:
+
+  | Field | Dtype | Shape | Units | Req | Notes |
+  |---|---|---|---|---|---|
+  | `translation` | float32 | `(T, 3)` | m | yes | Tip position (x,y,z) |
+  | `rotation` | float32 | `(T, 3)` or `(T, 4)` | – | yes | Euler or quaternion |
+  | `rotation_representation` | str | scalar | – | yes | `euler_xyz`, `quaternion_wxyz`, or `quaternion_xyzw` |
+  | `start_time_offset` | float32 | scalar | s | yes | Offset from first transmit (±) |
+  | `sampling_frequency` | float32 | scalar | Hz | no* | Pose rate |
+  | `timestamps` | float32 | `(T)` | s | no* | Per-sample times, relative to sample 0 |
+
+  *One of `sampling_frequency` or `timestamps` is needed to place poses in time.
+  Convention: **x = lateral, y = elevation (out-of-plane), z = axial (depth)**.
+
+- **`ecg` / `voice_narration` / custom `SignalND`**: `samples` (1D), plus
+  `start_time_offset` (s) and one of `sampling_frequency` / `timestamps`.
+
+## `/metrics` — quality (optional)
+
+`common_midpoint_phase_error` `(n_frames)`, `coherence_factor` `(n_frames)`.
+
+## Things that must never be there
+
+- Patient names, MRNs, DOBs, addresses, free-text identifiers
+- Filenames embedding identifiers; institutional IDs tied to a patient
+- Study codes that map back to identifiable records
+
+## Validation order (fail fast)
+
+1. Opens? (`zea.File(path)`)
+2. Required groups present? (`data`+`scan`, or `tracks`; `raw_data` for OpenH-RF)
+3. Spot-check shapes/dtypes against the tables above
+4. Validate units on a few key scalars (`sampling_frequency` Hz, `sound_speed` m/s,
+   `probe_geometry` m)
+5. Then proceed to deeper metadata / pose checks

--- a/.claude/skills/openh-rf-submission-eval/scripts/judge_bmode.py
+++ b/.claude/skills/openh-rf-submission-eval/scripts/judge_bmode.py
@@ -1,0 +1,90 @@
+"""
+Objective sanity checks on a reconstructed B-mode image.
+
+Used by dimension 2 (reconstruction) as a cheap, deterministic gate *before*
+the perceptual judgment. It does NOT assess image quality or similarity to a
+reference — that is done by the dimension-2 evaluator viewing the rendered
+image directly (multimodal vision). This script only answers: did the pipeline
+plausibly produce a real image rather than noise, a constant, or NaNs?
+
+(SSIM-vs-reference was removed: B-mode reconstructions and stored references
+typically live on different physical grids / scales and are not pixel-registered,
+which makes SSIM collapse toward zero even for visually-matching images. The
+"does this match the reference" question is now answered perceptually by the
+vision model — see references/dimensions/02-reconstruction.md.)
+"""
+
+from pathlib import Path
+
+import numpy as np
+
+
+def judge(image: np.ndarray) -> dict:
+    """Run objective sanity checks on a B-mode image.
+
+    Args:
+        image: 2D float array, the reconstructed B-mode image
+
+    Returns:
+        dict with keys: passed (bool), checks (dict of check_name -> dict)
+    """
+    checks = {}
+
+    # 1. Basic shape / dtype
+    checks["is_2d"] = {
+        "passed": image.ndim == 2,
+        "detail": f"ndim={image.ndim}",
+    }
+    checks["is_finite"] = {
+        "passed": bool(np.all(np.isfinite(image))),
+        "detail": f"nan_count={int(np.isnan(image).sum())}, "
+                  f"inf_count={int(np.isinf(image).sum())}",
+    }
+
+    # 2. Not degenerate
+    checks["has_variance"] = {
+        "passed": float(np.std(image)) > 1e-6,
+        "detail": f"std={float(np.std(image)):.4g}",
+    }
+    checks["not_all_one_value"] = {
+        "passed": len(np.unique(image)) > 10,
+        "detail": f"unique_values={len(np.unique(image))}",
+    }
+
+    # 3. Dynamic range plausible for log-compressed B-mode
+    rng = float(image.max() - image.min())
+    checks["dynamic_range_plausible"] = {
+        # Either normalized to [0, 1] with some spread, or dB-scale
+        "passed": 0.05 < rng < 200,
+        "detail": f"range={rng:.4g}, min={float(image.min()):.4g}, "
+                  f"max={float(image.max()):.4g}",
+    }
+
+    # 4. Spatial structure — variance along each axis
+    axial_std = float(np.std(image.mean(axis=1)))
+    lateral_std = float(np.std(image.mean(axis=0)))
+    checks["has_axial_structure"] = {
+        "passed": axial_std > 1e-4,
+        "detail": f"axial_profile_std={axial_std:.4g}",
+    }
+    checks["has_lateral_structure"] = {
+        "passed": lateral_std > 1e-4,
+        "detail": f"lateral_profile_std={lateral_std:.4g}",
+    }
+
+    passed = all(c["passed"] for c in checks.values())
+    return {"passed": passed, "checks": checks}
+
+
+if __name__ == "__main__":
+    import argparse
+    import json
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("image_npy", type=Path,
+                        help="Path to .npy file containing the reconstructed image")
+    args = parser.parse_args()
+
+    img = np.load(args.image_npy)
+    result = judge(img)
+    print(json.dumps(result, indent=2))

--- a/.claude/skills/openh-rf-submission-eval/scripts/pipeline_template.py
+++ b/.claude/skills/openh-rf-submission-eval/scripts/pipeline_template.py
@@ -1,0 +1,110 @@
+"""
+B-mode reconstruction pipeline template for OpenH-RF submissions.
+
+Used by the openh-rf-submission-eval skill when a submission is missing
+its reconstruction script. Fill in / adjust the operations as needed, then
+run against the submission's zea file.
+
+Standard chain:
+    raw channel data -> DAS beamforming -> envelope detection -> normalize -> log compression
+
+The canonical Pipeline docs are at
+https://zea.readthedocs.io/en/openh-rf-latest/pipeline.html — but note that the
+working pattern is:
+
+    pipeline = zea.Pipeline(operations=[...])           # or Pipeline.from_path("pipeline.yaml")
+    params   = pipeline.prepare_parameters(probe, scan) # geometry/grid from the file
+    outputs  = pipeline(**{pipeline.key: raw}, **params)
+    image    = keras.ops.convert_to_numpy(outputs[pipeline.output_key])[frame]
+"""
+
+import os
+from pathlib import Path
+
+# Default to the jax backend (installed by `uv sync`) before importing keras/zea.
+os.environ.setdefault("KERAS_BACKEND", "jax")
+
+import keras
+import numpy as np
+import zea
+from zea.ops import Beamform, EnvelopeDetect, LogCompress, Normalize
+
+
+def build_pipeline() -> "zea.Pipeline":
+    """Construct a default DAS -> envelope -> normalize -> log-compress pipeline.
+
+    The operations are geometry-agnostic; per-acquisition parameters (probe
+    geometry, sound speed, sampling frequency, transmit sequence, grid) are
+    derived from the zea file at run time via ``prepare_parameters`` — this is
+    what makes the pipeline portable across submissions.
+    """
+    return zea.Pipeline(
+        operations=[
+            Beamform(
+                beamformer="delay_and_sum",
+                num_patches=200,  # raise if you hit out-of-memory during beamforming
+            ),
+            EnvelopeDetect(),
+            Normalize(),
+            LogCompress(),
+        ]
+    )
+
+
+def reconstruct(
+    zea_path: Path,
+    frame_index: int = 0,
+    pipeline: "zea.Pipeline | None" = None,
+) -> np.ndarray:
+    """Reconstruct a single B-mode frame from a zea file.
+
+    Returns a 2D float array (log-compressed dB, typically in [-60, 0]).
+    """
+    zea.init_device()
+    with zea.File(str(zea_path)) as f:
+        probe = f.probe()
+        scan = f.scan()
+        raw = f.data.raw_data[:]
+
+    pipeline = pipeline or build_pipeline()
+    params = pipeline.prepare_parameters(probe, scan)
+    outputs = pipeline(**{pipeline.key: raw}, **params)
+    return keras.ops.convert_to_numpy(outputs[pipeline.output_key])[frame_index]
+
+
+if __name__ == "__main__":
+    import argparse
+
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("zea_file", type=Path, help="Path to the .hdf5 zea file")
+    parser.add_argument("--frame", type=int, default=0, help="Frame index (default: 0)")
+    parser.add_argument("--out", type=Path, default=Path("reference_bmode.png"))
+    parser.add_argument(
+        "--save-yaml",
+        type=Path,
+        default=None,
+        help="Optionally write the pipeline to a reusable pipeline.yaml",
+    )
+    args = parser.parse_args()
+
+    pipe = build_pipeline()
+    if args.save_yaml is not None:
+        pipe.to_yaml(str(args.save_yaml))
+        print(f"Saved pipeline to {args.save_yaml}")
+
+    bmode = reconstruct(args.zea_file, frame_index=args.frame, pipeline=pipe)
+
+    fig, ax = plt.subplots(figsize=(6, 8))
+    ax.imshow(bmode, cmap="gray", vmin=-60, vmax=0, aspect="auto")
+    ax.set_title(f"B-mode reconstruction — frame {args.frame}")
+    ax.set_xlabel("Lateral")
+    ax.set_ylabel("Axial (depth)")
+    fig.colorbar(ax.images[0], ax=ax, label="dB")
+    fig.tight_layout()
+    fig.savefig(args.out, dpi=150, bbox_inches="tight")
+    print(f"Saved reconstruction to {args.out}")

--- a/.claude/skills/openh-rf-submission-eval/scripts/validate_zea_spec.py
+++ b/.claude/skills/openh-rf-submission-eval/scripts/validate_zea_spec.py
@@ -1,0 +1,76 @@
+"""
+Validate a zea file against the installed zea data spec (programmatic).
+
+Used by dimension 1 (format compliance) as the authoritative check. Rather than
+comparing the file against a hand-maintained field list (which drifts out of
+date), this reconstructs zea's own ``FileSpec`` from the file via
+``FileSpec.from_hdf5`` — which runs every dtype / shape / dimension-consistency
+validation the spec defines in its ``__post_init__`` hooks. Compliance is
+therefore checked against *the zea version installed in the evaluation
+environment*; the reported ``zea_version`` records which spec was applied.
+
+If the spec reconstructs without error, the file is compliant with that zea
+version. If it raises, the exception message is the precise violation and
+becomes a dimension-1 finding.
+
+Usage:
+    python validate_zea_spec.py path/to/sample.hdf5
+
+Exit code 0 = compliant, 1 = non-compliant (machine-readable JSON on stdout).
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+# Default to the jax backend (installed by `uv sync`) before importing zea.
+os.environ.setdefault("KERAS_BACKEND", "jax")
+
+
+def validate(path: Path) -> dict:
+    import h5py
+    import zea
+    from zea.data.spec import FileSpec
+
+    result = {
+        "path": str(path),
+        "zea_version": zea.__version__,
+        "compliant": False,
+        "top_level_groups": [],
+        "data_groups": [],
+        "has_raw_data": False,
+        "errors": [],
+    }
+    try:
+        with h5py.File(str(path), "r") as hf:
+            result["top_level_groups"] = sorted(hf.keys())
+            if "data" in hf:
+                result["data_groups"] = sorted(hf["data"].keys())
+                result["has_raw_data"] = "raw_data" in hf["data"]
+            # The load-bearing check: reconstructing FileSpec re-runs every
+            # validation the installed zea spec defines.
+            FileSpec.from_hdf5(hf)
+        result["compliant"] = True
+    except Exception as e:  # noqa: BLE001 - any spec violation is a finding
+        result["errors"].append(f"{type(e).__name__}: {e}")
+
+    # OpenH-RF hard requirement, independent of spec construction.
+    if not result["has_raw_data"]:
+        result["compliant"] = False
+        result["errors"].append(
+            "BLOCKER: /data/raw_data is missing — raw pre-beamformed channel "
+            "capture data is mandatory for every OpenH-RF submission."
+        )
+    return result
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("zea_file", type=Path, help="Path to the .hdf5 zea file")
+    args = ap.parse_args()
+
+    r = validate(args.zea_file)
+    print(json.dumps(r, indent=2))
+    sys.exit(0 if r["compliant"] else 1)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# Agents in this repo
+
+Cross-agent instructions for AI tools (Claude Code, Codex CLI, OpenCode,
+Copilot CLI, Gemini CLI, etc.) operating on this repository.
+
+## Skills
+
+Project skills live under [`.claude/skills/`](./.claude/skills/), following the
+[Claude skill layout](https://docs.claude.com/en/docs/claude-code/skills). Each
+skill is a directory containing a `SKILL.md` plus any `references/` and
+`scripts/` it needs. The layout is just a directory of portable markdown, so
+non-Claude tools can read the same `SKILL.md` directly.
+
+Available skills:
+
+| Skill | Purpose |
+|---|---|
+| [`.claude/skills/openh-rf-submission-eval/`](./.claude/skills/openh-rf-submission-eval/) | Evaluate a contributor submission to the OpenH-RF initiative against the RFP and submission guide. Produces a structured acceptance report. |
+
+### Invocation per tool
+
+- **Claude Code** — auto-discovered from `.claude/skills/`; invoke via the `Skill` tool (or it triggers automatically when relevant).
+- **OpenAI Codex CLI** — point Codex at `.claude/skills/<name>/SKILL.md` via its agent/instruction config.
+- **OpenCode** — load `.claude/skills/<name>/SKILL.md` via the project agent loader.
+- **Other** — read `.claude/skills/<name>/SKILL.md` directly; the front-matter YAML names the skill and describes its trigger conditions.
+
+The `SKILL.md` content is portable markdown. Only the discovery mechanism is
+tool-specific — the rubrics, references, and scripts travel cleanly.
+
+## Conventions
+
+- `pyproject.toml` pins `zea`; use `uv sync` to set up the environment.
+- Linux-only is the supported platform; Windows users should use WSL2.


### PR DESCRIPTION
Ships the submission self-evaluation skill under .claude/skills/ so it is auto-discovered by Claude Code on clone; the SKILL.md is portable markdown that other agents (Codex, OpenCode, etc.) can read directly.