### PR TITLE
Bump pinned zea to current openh-rf-latest commit (0.1.0a4 -> 0.1.0a5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ uv run python examples/save_pipeline_example.py
 
 `uv sync` creates `.venv/` and installs dependencies listed in `pyproject.toml`. Run any script with `uv run python <script>.py`, or activate the venv with `source .venv/bin/activate`.
 
+`zea` is pinned in `uv.lock` to a specific commit of the moving [`openh-rf-latest`](https://github.com/tue-bmd/zea/tree/openh-rf-latest) tag, so every clone builds against the same spec. When the spec advances and you want the newer `zea`, bump the pin with `uv lock --upgrade-package zea` and commit the updated `uv.lock`.
+
 Pick a backend / accelerator with extras:
 
 | Use case | Command |

--- a/uv.lock
+++ b/uv.lock
@@ -5066,8 +5066,8 @@ wheels = [
 
 [[package]]
 name = "zea"
-version = "0.1.0a4"
-source = { git = "https://github.com/tue-bmd/zea.git?rev=openh-rf-latest#dd0375bcf2cd3f438f45802f24627d288e0b1c2d" }
+version = "0.1.0a5"
+source = { git = "https://github.com/tue-bmd/zea.git?rev=openh-rf-latest#dd21089228402dcefa93441553f4077fc989829d" }
 dependencies = [
     { name = "decorator" },
     { name = "grain", version = "0.2.13", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
zea is pinned via uv.lock to a specific commit of the moving openh-rf-latest tag. The pin had drifted behind the tag (locked dd0375bc / 0.1.0a4 vs current dd210892 / 0.1.0a5), so a fresh `uv sync` and CI's `uv sync --frozen` were building against a stale zea. Refresh the lock to the current tag tip; a plain `uv sync` now installs 0.1.0a5.

README: note that zea is pinned in uv.lock and how to bump it (`uv lock --upgrade-package zea`) when the spec advances.

CI is unchanged: `uv lock --check` + `uv sync --frozen` keep builds deterministic; zea is refreshed by deliberately re-locking, not by an automatic moving-target fetch.