### PR TITLE
Update templates to save `pipeline.yaml`

### DIFF
--- a/examples/templates/color-doppler/pipeline.yaml
+++ b/examples/templates/color-doppler/pipeline.yaml
@@ -1,22 +1,21 @@
-# Beamforming config for the color-doppler example.
-#
-# The dataset contains plane-wave RF data (n_ch=1) from a linear array.
-# This config beamforms the raw channel data to produce a B-mode image.
-
-parameters:
-  selected_transmits: all
-  n_ch: 1               # RF data
-  grid_size_x: 200      # lateral pixels
-  grid_size_z: 400      # axial pixels
-  xlims: [-0.015, 0.015] # metres
-  zlims: [0.001, 0.03]   # metres
-
 pipeline:
-  operations:
-    - name: beamform
-      params:
-        beamformer: delay_and_sum
-        num_patches: 100
-    - name: envelope_detect
-    - name: normalize
-    - name: log_compress
+    operations:
+    - beamform
+    - envelope_detect
+    -   name: normalize
+        params:
+            output_range:
+            - 0.0
+            - 1.0
+    - log_compress
+parameters:
+    selected_transmits: all
+    n_ch: 1
+    grid_size_x: 200
+    grid_size_z: 400
+    xlims:
+    - -0.015
+    - 0.015
+    zlims:
+    - 0.001
+    - 0.03

--- a/examples/templates/color-doppler/reconstruct.py
+++ b/examples/templates/color-doppler/reconstruct.py
@@ -1,8 +1,9 @@
 """Reconstruct: beamform the B-mode track from a duplex color-Doppler dataset.
 
-Loads the HDF5 file created by convert.py, selects the ``bmode`` track,
-reads its parameters and raw channel data, and runs a DAS beamforming
-pipeline defined in pipeline.yaml. The resulting B-mode image is saved as a PNG file.
+Defines a DAS beamforming pipeline in code, saves it (together with some beamforming
+parameters) to pipeline.yaml, then loads that YAML back and runs it. It selects the
+``bmode`` track of the HDF5 file created by convert.py, reads its parameters and raw
+channel data, beamforms them, and saves the resulting B-mode image as a PNG file.
 
 Note: the raw data in this example is synthetic (random noise), so the
 output image will appear as unstructured noise — this is expected.
@@ -22,11 +23,45 @@ import matplotlib.pyplot as plt
 import numpy as np
 import zea
 from zea import Config, File, Pipeline
+from zea.ops import Beamform, EnvelopeDetect, LogCompress, Normalize
 
 HERE = Path(__file__).parent
 INPUT = HERE / "color_doppler.hdf5"
 CONFIG = HERE / "pipeline.yaml"
 OUTPUT = HERE / "color_doppler_bmode.png"
+
+# Custom reconstruction parameters. These are passed to load_parameters and
+# override (or fill in) values read from the HDF5 file.
+#
+# The dataset contains plane-wave RF data (n_ch=1) from a linear array.
+PARAMETERS = {
+    "selected_transmits": "all",
+    "n_ch": 1,  # RF data
+    "grid_size_x": 200,  # lateral pixels
+    "grid_size_z": 400,  # axial pixels
+    "xlims": [-0.015, 0.015],  # metres
+    "zlims": [0.001, 0.03],  # metres
+}
+
+
+def build_pipeline() -> Pipeline:
+    """Define the delay-and-sum beamforming pipeline in code."""
+    return Pipeline(
+        operations=[
+            Beamform(beamformer="delay_and_sum", num_patches=100),
+            EnvelopeDetect(),
+            Normalize(),
+            LogCompress(),
+        ],
+        validate=False,
+    )
+
+
+def write_config(pipeline: Pipeline, path: Path) -> None:
+    """Serialize the pipeline and acquisition parameters to a YAML config file."""
+    config = pipeline.to_config()
+    config["parameters"] = PARAMETERS
+    config.to_yaml(str(path))
 
 
 def main():
@@ -44,7 +79,9 @@ def main():
     if not INPUT.exists():
         raise FileNotFoundError(f"{INPUT} not found. Run convert.py first.")
 
-    # Load beamforming config
+    # Define the beamforming pipeline in code, save it (with the acquisition
+    # parameters) to pipeline.yaml, then load that YAML back in.
+    write_config(build_pipeline(), CONFIG)
     config = Config.from_path(str(CONFIG))
     parameter_overrides = dict(config.parameters)
     parameter_overrides.setdefault("ylims", [0.0, 0.0])
@@ -60,7 +97,7 @@ def main():
     print(f"raw_data shape : {raw.shape}")
     print(f"grid           : {parameters.grid.shape}  (z, x, 3)")
 
-    # Build and run the beamforming pipeline defined in pipeline.yaml
+    # Build and run the beamforming pipeline loaded from pipeline.yaml
     pipeline = Pipeline.from_config(config)
     inputs = pipeline.prepare_parameters(parameters)
     outputs = pipeline(data=raw, **inputs)

--- a/examples/templates/echocardiography/pipeline.yaml
+++ b/examples/templates/echocardiography/pipeline.yaml
@@ -1,25 +1,25 @@
-# Beamforming config for the echocardiography example.
-#
-# The dataset contains focused-transmit RF data (n_ch=1) from a phased array.
-
-scan:
-    selected_transmits: all
-    n_ch: 1               # RF data
-    grid_size_x: 200      # lateral pixels
-    grid_size_z: 400      # axial pixels
-    pixels_per_wavelength: 2
-    f_number: 0.6
-    grid_type: polar # beamform on a polar grid
-    polar_limits: [-0.785398, 0.785398]
-    zlims: [0.0, 0.04]  # metres
-
 pipeline:
     operations:
-        - name: beamform
-          params:
-              beamformer: delay_and_sum
-              num_patches: 100
-        - envelope_detect
-        - normalize
-        - log_compress
-        - scan_convert # scan convert to Cartesian grid for display
+    - beamform
+    - envelope_detect
+    -   name: normalize
+        params:
+            output_range:
+            - 0.0
+            - 1.0
+    - log_compress
+    - scan_convert
+parameters:
+    selected_transmits: all
+    n_ch: 1
+    grid_size_x: 200
+    grid_size_z: 400
+    pixels_per_wavelength: 2
+    f_number: 0.6
+    grid_type: polar
+    polar_limits:
+    - -0.785398
+    - 0.785398
+    zlims:
+    - 0.0
+    - 0.04

--- a/examples/templates/echocardiography/reconstruct.py
+++ b/examples/templates/echocardiography/reconstruct.py
@@ -1,7 +1,9 @@
 """Reconstruct: load the echocardiography dataset and beamform the raw RF data.
 
-Loads the HDF5 file created by convert.py, reads the acquisition parameters and raw
-channel data, and runs a DAS beamforming pipeline defined in pipeline.yaml.
+Defines a DAS beamforming pipeline in code, saves it (together with some beamforming
+parameters) to pipeline.yaml, then loads that YAML back and runs it on the HDF5 file
+created by convert.py. The dataset is a focused-transmit phased-array acquisition, so
+the pipeline beamforms on a polar grid and scan-converts to Cartesian for display.
 The resulting B-mode image is saved as a PNG file.
 
 Note: the raw data in this example is synthetic (random noise), so the
@@ -22,11 +24,56 @@ import matplotlib.pyplot as plt
 import numpy as np
 import zea
 from zea import Config, File, Pipeline
+from zea.ops import (
+    Beamform,
+    EnvelopeDetect,
+    LogCompress,
+    Normalize,
+    ScanConvert,
+)
 
 HERE = Path(__file__).parent
 INPUT = HERE / "echocardiography.hdf5"
 CONFIG = HERE / "pipeline.yaml"
 OUTPUT = HERE / "echocardiography_bmode.png"
+
+# Custom reconstruction parameters. These are passed to load_parameters and
+# override (or fill in) values read from the HDF5 file.
+#
+# The dataset contains focused-transmit RF data (n_ch=1) from a phased array,
+# beamformed on a polar grid.
+PARAMETERS = {
+    "selected_transmits": "all",
+    "n_ch": 1,  # RF data
+    "grid_size_x": 200,  # lateral pixels
+    "grid_size_z": 400,  # axial pixels
+    "pixels_per_wavelength": 2,
+    "f_number": 0.6,
+    "grid_type": "polar",  # beamform on a polar grid
+    "polar_limits": [-0.785398, 0.785398],
+    "zlims": [0.0, 0.04],  # metres
+}
+
+
+def build_pipeline() -> Pipeline:
+    """Define the delay-and-sum beamforming pipeline in code."""
+    return Pipeline(
+        operations=[
+            Beamform(beamformer="delay_and_sum", num_patches=100),
+            EnvelopeDetect(),
+            Normalize(),
+            LogCompress(),
+            ScanConvert(),  # scan convert to Cartesian grid for display
+        ],
+        validate=False,
+    )
+
+
+def write_config(pipeline: Pipeline, path: Path) -> None:
+    """Serialize the pipeline and acquisition parameters to a YAML config file."""
+    config = pipeline.to_config()
+    config["parameters"] = PARAMETERS
+    config.to_yaml(str(path))
 
 
 def main():
@@ -44,7 +91,9 @@ def main():
     if not INPUT.exists():
         raise FileNotFoundError(f"{INPUT} not found. Run convert.py first.")
 
-    # Load beamforming config
+    # Define the beamforming pipeline in code, save it (with the acquisition
+    # parameters) to pipeline.yaml, then load that YAML back in.
+    write_config(build_pipeline(), CONFIG)
     config = Config.from_path(str(CONFIG))
 
     # Load file: read acquisition parameters (with config overrides) and raw data
@@ -57,7 +106,7 @@ def main():
     print(f"raw_data shape : {raw.shape}")
     print(f"grid           : {parameters.grid.shape}  (z, x, 3)")
 
-    # Build and run the beamforming pipeline defined in pipeline.yaml
+    # Build and run the beamforming pipeline loaded from pipeline.yaml
     pipeline = Pipeline.from_config(config)
     inputs = pipeline.prepare_parameters(parameters)
     outputs = pipeline(data=raw, **inputs)

--- a/examples/templates/segmentation/pipeline.yaml
+++ b/examples/templates/segmentation/pipeline.yaml
@@ -1,21 +1,21 @@
-# Beamforming config for the segmentation example.
-#
-# The dataset contains plane-wave RF data (n_ch=1) from a linear array.
-
-parameters:
-  selected_transmits: all
-  n_ch: 1               # RF data
-  grid_size_x: 200      # lateral pixels
-  grid_size_z: 400      # axial pixels
-  xlims: [-0.015, 0.015] # metres
-  zlims: [0.001, 0.03]   # metres
-
 pipeline:
-  operations:
-    - name: beamform
-      params:
-        beamformer: delay_and_sum
-        num_patches: 100
-    - name: envelope_detect
-    - name: normalize
-    - name: log_compress
+    operations:
+    - beamform
+    - envelope_detect
+    -   name: normalize
+        params:
+            output_range:
+            - 0.0
+            - 1.0
+    - log_compress
+parameters:
+    selected_transmits: all
+    n_ch: 1
+    grid_size_x: 200
+    grid_size_z: 400
+    xlims:
+    - -0.015
+    - 0.015
+    zlims:
+    - 0.001
+    - 0.03

--- a/examples/templates/segmentation/reconstruct.py
+++ b/examples/templates/segmentation/reconstruct.py
@@ -1,8 +1,8 @@
 """Reconstruct: load the segmentation dataset and beamform the raw RF data.
 
-Loads the HDF5 file created by convert.py, reads the acquisition parameters and raw
-channel data, and runs a DAS beamforming pipeline defined in pipeline.yaml.
-The resulting B-mode image is saved as a PNG file.
+Defines a DAS beamforming pipeline in code, saves it (together with some beamforming
+parameters) to pipeline.yaml, then loads that YAML back and runs it on the HDF5 file
+created by convert.py. The resulting B-mode image is saved as a PNG file.
 
 Note: the raw data in this example is synthetic (random noise), so the
 output image will appear as unstructured noise — this is expected.
@@ -22,11 +22,45 @@ import matplotlib.pyplot as plt
 import numpy as np
 import zea
 from zea import Config, File, Pipeline
+from zea.ops import Beamform, EnvelopeDetect, LogCompress, Normalize
 
 HERE = Path(__file__).parent
 INPUT = HERE / "segmentation.hdf5"
 CONFIG = HERE / "pipeline.yaml"
 OUTPUT = HERE / "segmentation_bmode.png"
+
+# Curstom reconstruction parameters. These are passed to load_parameters and
+# override (or fill in) values read from the HDF5 file.
+#
+# The dataset contains plane-wave RF data (n_ch=1) from a linear array.
+PARAMETERS = {
+    "selected_transmits": "all",
+    "n_ch": 1,  # RF data
+    "grid_size_x": 200,  # lateral pixels
+    "grid_size_z": 400,  # axial pixels
+    "xlims": [-0.015, 0.015],  # metres
+    "zlims": [0.001, 0.03],  # metres
+}
+
+
+def build_pipeline() -> Pipeline:
+    """Define the delay-and-sum beamforming pipeline in code."""
+    return Pipeline(
+        operations=[
+            Beamform(beamformer="delay_and_sum", num_patches=100),
+            EnvelopeDetect(),
+            Normalize(),
+            LogCompress(),
+        ],
+        validate=False,
+    )
+
+
+def write_config(pipeline: Pipeline, path: Path) -> None:
+    """Serialize the pipeline and acquisition parameters to a YAML config file."""
+    config = pipeline.to_config()
+    config["parameters"] = PARAMETERS
+    config.to_yaml(str(path))
 
 
 def main():
@@ -44,7 +78,9 @@ def main():
     if not INPUT.exists():
         raise FileNotFoundError(f"{INPUT} not found. Run convert.py first.")
 
-    # Load beamforming config
+    # Define the beamforming pipeline in code, save it (with the acquisition
+    # parameters) to pipeline.yaml, then load that YAML back in.
+    write_config(build_pipeline(), CONFIG)
     config = Config.from_path(str(CONFIG))
 
     # Load file: read acquisition parameters (with config overrides) and raw data
@@ -57,7 +93,7 @@ def main():
     print(f"raw_data shape : {raw.shape}")
     print(f"grid           : {parameters.grid.shape}  (z, x, 3)")
 
-    # Build and run the beamforming pipeline defined in pipeline.yaml
+    # Build and run the beamforming pipeline loaded from pipeline.yaml
     pipeline = Pipeline.from_config(config)
     inputs = pipeline.prepare_parameters(parameters)
     outputs = pipeline(data=raw, **inputs)

--- a/examples/templates/verasonics/pipeline.yaml
+++ b/examples/templates/verasonics/pipeline.yaml
@@ -1,27 +1,26 @@
-# Beamforming config for the Verasonics CIRS plane-wave phantom example.
-#
-# The acquisition uses plane-wave compounding with an L7-4 linear array.
-# RF data is demodulated before beamforming.
-
-parameters:
-  grid_size_x: 580
-  grid_size_z: 600
-  dynamic_range: [-40, 0]
-  zlims: [0.0065, 0.058]
-  apply_lens_correction: true
-  # lens_thickness and lens_sound_speed are read from the probe spec in the file.
-  # convert.py derives them from the Verasonics lens_correction custom element.
-
 pipeline:
-  operations:
-    - name: keras.ops.cast
-      params:
-        dtype: float32
-    - name: demodulate
-    - name: beamform
-      params:
-        beamformer: delay_and_sum
-        num_patches: 200
-    - name: envelope_detect
-    - name: normalize
-    - name: log_compress
+    operations:
+    -   name: keras.ops.cast
+        params:
+            dtype: float32
+    - demodulate
+    -   name: beamform
+        params:
+            num_patches: 200
+    - envelope_detect
+    -   name: normalize
+        params:
+            output_range:
+            - 0.0
+            - 1.0
+    - log_compress
+parameters:
+    grid_size_x: 580
+    grid_size_z: 600
+    dynamic_range:
+    - -40
+    - 0
+    zlims:
+    - 0.0065
+    - 0.058
+    apply_lens_correction: true

--- a/examples/templates/verasonics/reconstruct.py
+++ b/examples/templates/verasonics/reconstruct.py
@@ -1,8 +1,8 @@
 """Reconstruct: beamform the Verasonics plane-wave phantom using DAS.
 
-Loads the HDF5 file created by convert.py, reads the acquisition parameters and
-raw RF data, and runs a delay-and-sum beamforming pipeline configured in
-pipeline.yaml. The resulting B-mode image is saved as a PNG file.
+Defines a delay-and-sum beamforming pipeline in code, saves it (together with some
+beamforming parameters) to pipeline.yaml, then loads that YAML back and runs it on
+the HDF5 file created by convert.py. The resulting B-mode image is saved as a PNG file.
 
 Usage:
     python examples/templates/verasonics/reconstruct.py
@@ -20,11 +20,51 @@ import matplotlib.pyplot as plt
 import numpy as np
 import zea
 from zea import Config, File, Pipeline
+from zea.ops import (
+    Beamform,
+    Cast,
+    Demodulate,
+    EnvelopeDetect,
+    LogCompress,
+    Normalize,
+)
 
 HERE = Path(__file__).parent
 DEFAULT_INPUT = HERE / "verasonics_sample.hdf5"
 DEFAULT_OUTPUT = HERE / "verasonics_bmode.png"
 CONFIG = HERE / "pipeline.yaml"
+
+# Custom reconstruction parameters. These are passed to load_parameters and
+# override (or fill in) values read from the HDF5 file.
+PARAMETERS = {
+    "grid_size_x": 580,
+    "grid_size_z": 600,
+    "dynamic_range": [-40, 0],
+    "zlims": [0.0065, 0.058],
+    "apply_lens_correction": True,
+}
+
+
+def build_pipeline() -> Pipeline:
+    """Define the delay-and-sum beamforming pipeline in code."""
+    return Pipeline(
+        operations=[
+            Cast(dtype="float32"),
+            Demodulate(),
+            Beamform(beamformer="delay_and_sum", num_patches=200),
+            EnvelopeDetect(),
+            Normalize(),
+            LogCompress(),
+        ],
+        validate=False,
+    )
+
+
+def write_config(pipeline: Pipeline, path: Path) -> None:
+    """Serialize the pipeline and acquisition parameters to a YAML config file."""
+    config = pipeline.to_config()
+    config["parameters"] = PARAMETERS
+    config.to_yaml(str(path))
 
 
 def main():
@@ -44,7 +84,9 @@ def main():
     if not args.input.exists():
         raise FileNotFoundError(f"{args.input} not found. Run convert.py first.")
 
-    # Load beamforming config
+    # Define the beamforming pipeline in code, save it (with the acquisition
+    # parameters) to pipeline.yaml, then load that YAML back in.
+    write_config(build_pipeline(), CONFIG)
     config = Config.from_path(str(CONFIG))
 
     # Load file: read acquisition parameters (with config overrides) and raw RF data
@@ -52,7 +94,7 @@ def main():
         parameters = f.load_parameters(**config.parameters)
         raw = f.data.raw_data[:]  # (n_frames, n_tx, n_ax, n_el, 1) — RF
 
-    # Build and run the beamforming pipeline defined in pipeline.yaml
+    # Build and run the beamforming pipeline loaded from pipeline.yaml
     pipeline = Pipeline.from_config(config)
     inputs = pipeline.prepare_parameters(parameters)
 


### PR DESCRIPTION
As discussed, we want the templates to create and save the `pipeline.yaml` from a zea pipeline as well as loading it for reconstruction, to show submitters how to create their own pipelines in code.

This PR updates the templates to do that.