### PR TITLE
Fix PALA convert.py against current pinned zea

### DIFF
--- a/examples/pala-ulm-ratbrain/convert.py
+++ b/examples/pala-ulm-ratbrain/convert.py
@@ -21,6 +21,7 @@ import h5py
 import numpy as np
 import requests
 import zea
+import zea.data.convert.verasonics  # noqa: F401  (registers the submodule attribute)
 from tqdm import tqdm
 from zea import File
 
@@ -77,7 +78,7 @@ def convert(path: Path, output_path: Path) -> Path:
         prf_hz = _scalar(rf.attrs["PRF_Hz"])
         if prf_hz >= 32767:
             prf_hz = _scalar(rf.attrs["framerate_Hz"]) * _scalar(rf.attrs["num_angles"])
-        time_to_next_transmit = 1.0 / prf_hz
+        time_to_next_transmit = 1.0 / prf_hz  # scalar seconds; broadcast below
 
         element_width = _scalar(us_probe.attrs["element_width_mm"]) * 1e-3
 
@@ -106,7 +107,9 @@ def convert(path: Path, output_path: Path) -> Path:
         "transmit_origins": np.zeros((n_tx, 3), dtype=np.float32),
         "waveforms_two_way": waveforms_two_way,
         "waveforms_one_way": waveforms_one_way,
-        "time_to_next_transmit": time_to_next_transmit,
+        "time_to_next_transmit": np.full(
+            (n_frames, n_tx), time_to_next_transmit, dtype=np.float32
+        ),
     }
 
     metadata = {


### PR DESCRIPTION
Running the PALA example as documented (`uv sync`, then `uv run python examples/pala-ulm-ratbrain/convert.py --download`) fails at two points against the `zea` version pinned in `uv.lock`:

1. **`AttributeError: module 'zea.data.convert' has no attribute 'verasonics'`** — the `verasonics` submodule is not imported by the parent package, so the attribute access `zea.data.convert.verasonics.bs100bw_to_iq(...)` in `convert()` fails. Fixed by importing the submodule explicitly.

2. **`ValueError: In field 'scan': time_to_next_transmit has shape (), expected one of: ('n_frames', 'n_tx'), ('n_timing_intervals',)`** — the spec no longer accepts a scalar. Fixed by broadcasting the scalar `1/PRF` to an `(n_frames, n_tx)` float32 array.

Verified end-to-end on `RF_002.hdf5` (macOS arm64, JAX CPU backend): conversion writes `pala_sample.hdf5` (616.5 MB) and `reconstruct.py` beamforms all 800 frames to the expected rat-brain B-mode.

Unrelated observation while reproducing, in case it's worth a follow-up: single-stream downloads from Zenodo were heavily throttled (~0.2 MB/s) and `_download_if_absent` treats any existing partial file as complete, so an interrupted download silently produces a corrupt zip on the next run. Happy to file separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)